### PR TITLE
Fix exercise template assignment bug

### DIFF
--- a/apps/tracker-api/src/modules/exercises/domain/exercise.entity.ts
+++ b/apps/tracker-api/src/modules/exercises/domain/exercise.entity.ts
@@ -171,7 +171,7 @@ class ExerciseEntity {
         'assignToTemplate',
       );
     }
-    if (this.data.trainingId != null) {
+    if (this.data.trainingTemplateId != null) {
       validator.throwError(
         `You can not assign exercise: ${this.data.id} to template: ${input.trainingTemplateId} if it has already assigned to training`,
         'assignToTemplate',

--- a/apps/tracker-api/src/shared/lib/validator.ts
+++ b/apps/tracker-api/src/shared/lib/validator.ts
@@ -62,7 +62,7 @@ class Validator {
       throw new DomainValidationError({
         field,
         domain: this.domain,
-        message: `id must not be valid id:${value}`,
+        message: `${field} must be a valid id: ${value}`,
       });
     }
   }


### PR DESCRIPTION
## Summary
- fix incorrect validation when assigning exercise to template
- correct validator error message for ID checks

## Testing
- `pnpm -r test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e568e2108328a779d49ec48a0e73