### PR TITLE
Fix JWT verify options in AuthGuard

### DIFF
--- a/apps/tracker-api/src/modules/auth/guards/auth.guard.ts
+++ b/apps/tracker-api/src/modules/auth/guards/auth.guard.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { APP_ENV } from '@/infrastructure/configs';
 import { Reflector } from '@nestjs/core';
 import { IS_PUBLIC_KEY, PAYLOAD_KEY } from '../decorators';
+import { AccessTokenPayload } from '../dto/access-token.dto';
 import { ExceptionUnauthorized } from '@big-d/api-exception';
 
 @Injectable()
@@ -36,9 +37,9 @@ export class AuthGuard implements CanActivate {
     const token = authHeader.split(' ')[1];
 
     try {
-      request[PAYLOAD_KEY] = await this.jwtService.verifyAsync<{ userId: number }>(
+      request[PAYLOAD_KEY] = await this.jwtService.verifyAsync<AccessTokenPayload>(
         token,
-        this.configService.get('AUTH_SECRET_KEY'),
+        { secret: this.configService.get('AUTH_SECRET_KEY') },
       );
 
       return true;


### PR DESCRIPTION
## Summary
- use `AccessTokenPayload` when verifying access token
- pass JWT secret through verify options

## Testing
- `pnpm -r test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e723c90c8328916ff06ba6594643