### PR TITLE
Fix git line endings for images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,13 @@
-*.* text eol=lf
+* text=auto
+
+# Ensure IDE configuration files use LF line endings
 /.idea/* text eol=lf
+
+# Treat common binary assets as binary to avoid EOL conversions
+*.png -text
+*.jpg -text
+*.jpeg -text
+*.gif -text
+*.ico -text
+*.webp -text
+*.pdf -text


### PR DESCRIPTION
## Summary
- avoid eol conversion on binary assets

## Testing
- `pnpm -r lint` *(fails: Cannot find package '@big-d/linter' when running prettier)*
- `pnpm -r test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e901b0fc832890d10b1c529fe834