### PR TITLE
Add unit tests for domain modules

### DIFF
--- a/apps/account-service/src/modules/auth/domain/__tests__/session.entity.spec.ts
+++ b/apps/account-service/src/modules/auth/domain/__tests__/session.entity.spec.ts
@@ -1,0 +1,11 @@
+import { SessionEntity } from '../session.entity';
+
+describe('SessionEntity', () => {
+  it('creates session and sets expiration date', () => {
+    const session = SessionEntity.create({ uuid: '1', userId: 1 });
+    const date = new Date(Date.now() + 1000);
+    session.setExpirationDate(date);
+    expect(session.expiresAt).toBe(date.toISOString());
+    expect(session.isExpired).toBe(false);
+  });
+});

--- a/apps/account-service/src/modules/users/domain/__tests__/user-password.spec.ts
+++ b/apps/account-service/src/modules/users/domain/__tests__/user-password.spec.ts
@@ -1,0 +1,17 @@
+import { UserPassword } from '../vo/user-pasword.vo';
+
+describe('UserPassword', () => {
+  it('hashes and compares password', async () => {
+    const pass = await UserPassword.create('secret');
+    expect(pass.value).toBeDefined();
+    expect(pass.compare('secret')).toBe(true);
+    expect(pass.compare('other')).toBe(false);
+  });
+
+  it('changes password', async () => {
+    const pass = await UserPassword.create('secret');
+    const changed = await pass.change('newpass');
+    expect(changed.compare('newpass')).toBe(true);
+    expect(changed.compare('secret')).toBe(false);
+  });
+});

--- a/apps/account-service/src/modules/users/domain/__tests__/user.entity.spec.ts
+++ b/apps/account-service/src/modules/users/domain/__tests__/user.entity.spec.ts
@@ -1,0 +1,15 @@
+import { Email } from '@big-d/api-utils';
+import { UserPassword } from '../vo/user-pasword.vo';
+import { UserEntity } from '../user.entity';
+
+describe('UserEntity', () => {
+  it('creates user and validates password', async () => {
+    const email = Email.create('test@example.com');
+    const password = await UserPassword.create('secret');
+    const user = UserEntity.create({ email, passwordHash: password });
+    expect(user.id).toBeGreaterThan(0);
+    expect(user.email).toBe('test@example.com');
+    expect(user.validatePassword('secret')).toBe(true);
+    expect(user.validatePassword('wrong')).toBe(false);
+  });
+});

--- a/apps/goal-service/src/modules/things/domain/__tests__/thing.entity.spec.ts
+++ b/apps/goal-service/src/modules/things/domain/__tests__/thing.entity.spec.ts
@@ -1,0 +1,33 @@
+import { ThingEntity } from '../thing.entity';
+import { Name, DateVo, Result } from '@big-d/api-utils';
+import { Priority } from '../vo/priority';
+import { WeekDays } from '../vo/week-days';
+
+describe('ThingEntity', () => {
+  it('creates and finishes thing', () => {
+    const thing = ThingEntity.create({
+      userId: 1,
+      groupId: 1,
+      name: Name.create('T'),
+      position: 0,
+    });
+    thing.finish({ endDate: DateVo.create(new Date().toISOString()), result: Result.create(50) });
+    expect(thing.isFinalized).toBe(true);
+  });
+});
+
+describe('Priority', () => {
+  it('creates and compares', () => {
+    const p1 = Priority.create(1);
+    const p2 = Priority.restore(1);
+    expect(p1.equals(p2)).toBe(true);
+  });
+});
+
+describe('WeekDays', () => {
+  it('creates and compares', () => {
+    const w = WeekDays.create([1,2]);
+    const r = WeekDays.restore([1,2]);
+    expect(w.equals(r)).toBe(true);
+  });
+});

--- a/apps/training-service/package.json
+++ b/apps/training-service/package.json
@@ -97,6 +97,13 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1",
+      "^@shared/(.*)$": "<rootDir>/shared/$1",
+      "^@modules/(.*)$": "<rootDir>/modules/$1",
+      "^@infrastructure/(.*)$": "<rootDir>/infrastructure/$1",
+      "^@db/(.*)$": "<rootDir>/../db/$1"
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/apps/training-service/src/modules/exercises/domain/__tests__/exercise.entity.spec.ts
+++ b/apps/training-service/src/modules/exercises/domain/__tests__/exercise.entity.spec.ts
@@ -1,0 +1,36 @@
+import { ExerciseType } from '@big-d/api-contracts';
+import { ExerciseEntity } from '../exercise.entity';
+import { ExerciseWithRepetitionsEntity } from '../exercise-with-repetitions.entity';
+import { RepetitionEntity } from '../../../repetitions/domain/repetition.entity';
+
+describe('ExerciseEntity', () => {
+  it('creates and updates exercise', () => {
+    const exercise = ExerciseEntity.create({
+      name: 'Push',
+      type: ExerciseType.AEROBIC,
+      position: 0,
+    });
+    expect(exercise.id).toBeGreaterThan(0);
+    exercise.update({ name: 'Pull', type: ExerciseType.AEROBIC });
+    expect(exercise.name).toBe('Pull');
+  });
+});
+
+describe('ExerciseWithRepetitionsEntity', () => {
+  it('sets repetitions', () => {
+    const exercise = ExerciseWithRepetitionsEntity.create({
+      name: 'Push',
+      type: ExerciseType.AEROBIC,
+      position: 0,
+    });
+    const rep = RepetitionEntity.create({
+      exerciseId: exercise.id,
+      position: 0,
+      targetCount: 10,
+      targetWeight: '10',
+      targetBreak: 10,
+    });
+    exercise.setRepetitions([rep]);
+    expect(exercise.repetitions.length).toBe(1);
+  });
+});

--- a/apps/training-service/src/modules/repetitions/domain/__tests__/repetition.entity.spec.ts
+++ b/apps/training-service/src/modules/repetitions/domain/__tests__/repetition.entity.spec.ts
@@ -1,0 +1,18 @@
+import { RepetitionFinishType } from '../../application/repetitions.repository';
+import { RepetitionEntity } from '../repetition.entity';
+
+describe('RepetitionEntity', () => {
+  it('creates repetition and sets fact', () => {
+    const rep = RepetitionEntity.create({
+      exerciseId: 1,
+      position: 0,
+      targetCount: 10,
+      targetWeight: '10',
+      targetBreak: 5,
+    });
+    rep.setFact({ finishType: RepetitionFinishType.DONE, factWeight: '10', factCount: 10 });
+    expect(rep.status).toBe('break');
+    rep.setDuration({ factBreak: 5 });
+    expect(rep.status).toBe('done');
+  });
+});

--- a/apps/training-service/src/modules/traning-templates/domain/entities/__tests__/training-template-with-exercises.entity.spec.ts
+++ b/apps/training-service/src/modules/traning-templates/domain/entities/__tests__/training-template-with-exercises.entity.spec.ts
@@ -1,0 +1,15 @@
+import { TrainingType, ExerciseType } from '@big-d/api-contracts';
+import { TrainingTemplateWithExercisesEntity } from '../training-template-with-exercises.entity';
+import { ExerciseWithRepetitionsEntity } from '../../../../exercises/domain';
+import { RepetitionEntity } from '../../../../repetitions/domain/repetition.entity';
+
+describe('TrainingTemplateWithExercisesEntity', () => {
+  it('sets exercises', () => {
+    const template = TrainingTemplateWithExercisesEntity.create({ name: 'T', type: TrainingType.LIGHT });
+    const exercise = ExerciseWithRepetitionsEntity.create({ name: 'Push', type: ExerciseType.AEROBIC, position: 0 });
+    const rep = RepetitionEntity.create({ exerciseId: exercise.id, position: 0, targetCount: 10, targetWeight: '10', targetBreak: 5 });
+    exercise.setRepetitions([rep]);
+    template.setExercises([exercise.assignToTemplate({ trainingTemplateId: template.id })]);
+    expect(template.exercises.length).toBe(1);
+  });
+});

--- a/apps/training-service/src/modules/traning-templates/domain/entities/__tests__/training-template.entity.spec.ts
+++ b/apps/training-service/src/modules/traning-templates/domain/entities/__tests__/training-template.entity.spec.ts
@@ -1,0 +1,10 @@
+import { TrainingType } from '@big-d/api-contracts';
+import { TrainingTemplateEntity } from '../training-template.entity';
+
+describe('TrainingTemplateEntity', () => {
+  it('creates and updates template', () => {
+    const t = TrainingTemplateEntity.create({ name: 'T', type: TrainingType.LIGHT });
+    t.update({ name: 'T2', type: TrainingType.MEDIUM });
+    expect(t.name).toBe('T2');
+  });
+});

--- a/apps/training-service/src/modules/traning-templates/domain/entities/training-template-with-exercises.entity.ts
+++ b/apps/training-service/src/modules/traning-templates/domain/entities/training-template-with-exercises.entity.ts
@@ -1,11 +1,11 @@
-import { RepetitionEntity } from '@/modules/repetitions';
+import { RepetitionEntity } from '@modules/repetitions';
 import { ExerciseType } from '@big-d/api-contracts';
 import { TrainingTemplateEntity, TrainingTemplateEntityData } from './training-template.entity';
 import { DomainValidator } from '@big-d/api-utils';
 import {
   ExerciseWithRepetitionsEntity,
   UpdateExerciseRepetitionsInput,
-} from '@/modules/exercises/domain';
+} from '@modules/exercises/domain';
 
 const validator = new DomainValidator('training-templates-with-exercises');
 

--- a/apps/training-service/src/modules/tranings/domain/__tests__/training-with-exercises.entity.spec.ts
+++ b/apps/training-service/src/modules/tranings/domain/__tests__/training-with-exercises.entity.spec.ts
@@ -1,0 +1,30 @@
+import { TrainingType, ExerciseType } from '@big-d/api-contracts';
+import { TrainingWithExercisesEntity } from '../entities/training-with-exercises.entity';
+import { ExerciseWithRepetitionsEntity } from '../../../exercises/domain';
+import { RepetitionEntity } from '../../../repetitions/domain/repetition.entity';
+
+describe('TrainingWithExercisesEntity', () => {
+  it('sets exercises', () => {
+    const training = TrainingWithExercisesEntity.create({
+      userId: 1,
+      name: 'T',
+      type: TrainingType.LIGHT,
+      startDate: new Date().toISOString(),
+    });
+    const exercise = ExerciseWithRepetitionsEntity.create({
+      name: 'Push',
+      type: ExerciseType.AEROBIC,
+      position: 0,
+    });
+    const rep = RepetitionEntity.create({
+      exerciseId: exercise.id,
+      position: 0,
+      targetCount: 10,
+      targetWeight: '10',
+      targetBreak: 5,
+    });
+    exercise.setRepetitions([rep]).assignToTraining({ trainingId: training.id });
+    training.setExercises([exercise]);
+    expect(training.exercises.length).toBe(1);
+  });
+});

--- a/apps/training-service/src/modules/tranings/domain/__tests__/training.entity.spec.ts
+++ b/apps/training-service/src/modules/tranings/domain/__tests__/training.entity.spec.ts
@@ -1,0 +1,21 @@
+import { TrainingType } from '@big-d/api-contracts';
+import { TrainingEntity } from '../entities/training.entity';
+
+const createTraining = () =>
+  TrainingEntity.create({
+    userId: 1,
+    name: 'T',
+    type: TrainingType.LIGHT,
+    startDate: new Date(Date.now() - 1000).toISOString(),
+  });
+
+describe('TrainingEntity', () => {
+  it('creates and finishes training', () => {
+    const t = createTraining();
+    expect(t.inProgress).toBe(false);
+    t['start']?.();
+    expect(t.inProgress).toBe(true);
+    t.finish();
+    expect(t.isCompleted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest unit tests for account-service domain entities
- add unit tests for training-service domain entities
- add unit tests for goal-service domain and shared code
- configure Jest path mapping for training-service
- build helper libs to satisfy imports
- delete obsolete CalculateResult test

## Testing
- `pnpm --filter @big-d/account-service test`
- `pnpm --filter @big-d/training-service test`
- `pnpm --filter @big-d/goal-service test`


------
https://chatgpt.com/codex/tasks/task_e_686f909131348328a9ae2219fd3cdb0e