### PR TITLE
Add SQL query tests for Kysely task repositories

### DIFF
--- a/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/__tests__/kysely-test-utils.ts
+++ b/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/__tests__/kysely-test-utils.ts
@@ -1,0 +1,99 @@
+import { DB } from '@/infrastructure/types';
+import { Database } from '@/modules/tasks/application/ports';
+import {
+  CompiledQuery,
+  DatabaseConnection,
+  Dialect,
+  Driver,
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  Transaction,
+} from 'kysely';
+
+type QueryResult = {
+  rows: Array<Record<string, unknown>>;
+  numAffectedRows?: bigint;
+  numChangedRows?: bigint;
+  insertId?: bigint;
+};
+
+class SqlCaptureConnection implements DatabaseConnection {
+  constructor(
+    private readonly queries: CompiledQuery[],
+    private readonly results: QueryResult[],
+  ) {}
+
+  async executeQuery<R>(compiledQuery: CompiledQuery): Promise<{ rows: R[] }> {
+    this.queries.push(compiledQuery);
+    return (this.results.shift() ?? { rows: [] }) as { rows: R[] };
+  }
+
+  async *streamQuery(): AsyncIterableIterator<{ rows: unknown[] }> {
+    throw new Error('streamQuery is not supported in SQL capture tests');
+  }
+}
+
+class SqlCaptureDriver implements Driver {
+  constructor(
+    private readonly queries: CompiledQuery[],
+    private readonly results: QueryResult[],
+  ) {}
+
+  async init(): Promise<void> {}
+
+  async acquireConnection(): Promise<DatabaseConnection> {
+    return new SqlCaptureConnection(this.queries, this.results);
+  }
+
+  async beginTransaction(): Promise<void> {}
+
+  async commitTransaction(): Promise<void> {}
+
+  async rollbackTransaction(): Promise<void> {}
+
+  async releaseConnection(): Promise<void> {}
+
+  async destroy(): Promise<void> {}
+}
+
+class SqlCaptureDialect implements Dialect {
+  constructor(
+    private readonly queries: CompiledQuery[],
+    private readonly results: QueryResult[],
+  ) {}
+
+  createAdapter() {
+    return new PostgresAdapter();
+  }
+
+  createDriver() {
+    return new SqlCaptureDriver(this.queries, this.results);
+  }
+
+  createQueryCompiler() {
+    return new PostgresQueryCompiler();
+  }
+
+  createIntrospector(db: Kysely<unknown>) {
+    return new PostgresIntrospector(db);
+  }
+}
+
+const createSqlCaptureDb = (results: QueryResult[] = []) => {
+  const queries: CompiledQuery[] = [];
+  const kysely = new Kysely<DB>({
+    dialect: new SqlCaptureDialect(queries, results),
+  });
+  const db = {
+    qb: (trx?: Transaction<DB>) => trx ?? kysely,
+  } as Database<DB>;
+
+  return { db, queries };
+};
+
+const serializeQueries = (queries: CompiledQuery[]) =>
+  queries.map(({ sql, parameters }) => ({ sql, parameters }));
+
+export { QueryResult, createSqlCaptureDb, serializeQueries };

--- a/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/base-tasks.repository.test.ts
+++ b/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/base-tasks.repository.test.ts
@@ -1,0 +1,20 @@
+import { ExceptionTaskInfrastructure } from '@/modules/tasks/infrastructure/exceptions';
+import { BaseTasksRepository } from './base-tasks.repository';
+
+describe('BaseTasksRepository', () => {
+  it('returns the callback result', async () => {
+    const repository = new BaseTasksRepository();
+
+    await expect(repository.errorCatcher('noop', async () => 42)).resolves.toBe(42);
+  });
+
+  it('wraps errors with ExceptionTaskInfrastructure', async () => {
+    const repository = new BaseTasksRepository();
+
+    await expect(
+      repository.errorCatcher('tasks.test', async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toBeInstanceOf(ExceptionTaskInfrastructure);
+  });
+});

--- a/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/helpers/helpers.test.ts
+++ b/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/helpers/helpers.test.ts
@@ -1,0 +1,68 @@
+import { INBOX_GROUP_KEY } from '@/modules/tasks/application/ports';
+import {
+  firstOrThrowError,
+  getAvailableGroupQuery,
+  getGroupWithStatusQuery,
+  getInboxByUserIdQuery,
+  getTasksWithStatusQuery,
+} from './index';
+import { createSqlCaptureDb } from '../__tests__/kysely-test-utils';
+
+describe('kysely repository helpers', () => {
+  it('builds getTasksWithStatusQuery SQL', () => {
+    const { db } = createSqlCaptureDb();
+
+    const compiled = getTasksWithStatusQuery(db).compile();
+
+    expect(compiled.sql).toBe(
+      'select "t"."id" as "id", "t"."user_id" as "user_id", "t"."name" as "name", "t"."description" as "description", "t"."priority" as "priority", "t"."weight" as "weight", "t"."cancel_reason" as "cancel_reason", "t"."start_date" as "start_date", "t"."end_date" as "end_date", "t"."deadline" as "deadline", "t"."recurrence" as "recurrence", "ts"."name" as "status" from "tasks" as "t" inner join "task_statuses" as "ts" on "t"."status_id" = "ts"."id"',
+    );
+    expect(compiled.parameters).toEqual([]);
+  });
+
+  it('builds getGroupWithStatusQuery SQL', () => {
+    const { db } = createSqlCaptureDb();
+
+    const compiled = getGroupWithStatusQuery(db).compile();
+
+    expect(compiled.sql).toBe(
+      'select "g"."id" as "id", "g"."user_id" as "user_id", "g"."description" as "description", "g"."name" as "name", "gs"."name" as "status", "g"."progress" as "progress" from "groups" as "g" inner join "group_statuses" as "gs" on "g"."status_id" = "gs"."id"',
+    );
+    expect(compiled.parameters).toEqual([]);
+  });
+
+  it('builds getAvailableGroupQuery SQL', () => {
+    const { db } = createSqlCaptureDb();
+
+    const compiled = getAvailableGroupQuery(db).compile();
+
+    expect(compiled.sql).toBe(
+      'select "g"."id" as "id", "g"."user_id" as "user_id", "g"."description" as "description", "g"."name" as "name", "gs"."name" as "status", "g"."progress" as "progress" from "groups" as "g" inner join "group_statuses" as "gs" on "g"."status_id" = "gs"."id" where "g"."name" not in ($1)',
+    );
+    expect(compiled.parameters).toEqual([INBOX_GROUP_KEY]);
+  });
+
+  it('builds getInboxByUserIdQuery SQL', () => {
+    const { db } = createSqlCaptureDb();
+
+    const compiled = getInboxByUserIdQuery(db, { userId: 4 }).compile();
+
+    expect(compiled.sql).toBe(
+      'select "g"."id" as "id", "g"."user_id" as "user_id", "g"."name" as "name" from "groups" as "g" left join "task_to_group" as "ttg" on "ttg"."group_id" = "g"."id" where "g"."name" = $1 and "g"."user_id" = $2',
+    );
+    expect(compiled.parameters).toEqual([INBOX_GROUP_KEY, 4]);
+  });
+
+  it('chooses the correct first-or-throw branch', async () => {
+    const executeTakeFirst = jest.fn(async () => undefined);
+    const executeTakeFirstOrThrow = jest.fn(async () => ({ id: 1 }));
+
+    await expect(firstOrThrowError({ executeTakeFirst, executeTakeFirstOrThrow }, {})).resolves.toBeNull();
+    await expect(
+      firstOrThrowError({ executeTakeFirst, executeTakeFirstOrThrow }, { throwError: true }),
+    ).resolves.toEqual({ id: 1 });
+
+    expect(executeTakeFirst).toHaveBeenCalledTimes(1);
+    expect(executeTakeFirstOrThrow).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/read/group-inbox.read-repository.kysely.test.ts
+++ b/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/read/group-inbox.read-repository.kysely.test.ts
@@ -1,0 +1,64 @@
+import { TaskStatus } from '@big-d/api-contracts';
+import { GroupInboxReadRepositoryKysely } from './group-inbox.read-repository.kysely';
+import { createSqlCaptureDb, serializeQueries } from '../__tests__/kysely-test-utils';
+
+describe('GroupInboxReadRepositoryKysely', () => {
+  it('builds SQL for getInboxWithTasksByUserId', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      { rows: [{ id: 1, name: 'Inbox', user_id: 4 }] },
+      {
+        rows: [
+          {
+            id: 10,
+            user_id: 4,
+            name: 'Task',
+            description: 'd',
+            priority: 1,
+            weight: 2,
+            cancel_reason: null,
+            start_date: null,
+            end_date: null,
+            deadline: null,
+            recurrence: null,
+            status: TaskStatus.NOT_STARTED,
+          },
+        ],
+      },
+    ]);
+    const repository = new GroupInboxReadRepositoryKysely(db);
+
+    await repository.getInboxWithTasksByUserId({ userId: 4 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select "g"."id" as "id", "g"."user_id" as "user_id", "g"."name" as "name" from "groups" as "g" left join "task_to_group" as "ttg" on "ttg"."group_id" = "g"."id" where "g"."name" = $1 and "g"."user_id" = $2',
+        parameters: ['IN_BOX', 4],
+      },
+      {
+        sql: 'select "t"."id" as "id", "t"."user_id" as "user_id", "t"."name" as "name", "t"."description" as "description", "t"."priority" as "priority", "t"."weight" as "weight", "t"."cancel_reason" as "cancel_reason", "t"."start_date" as "start_date", "t"."end_date" as "end_date", "t"."deadline" as "deadline", "t"."recurrence" as "recurrence", "ts"."name" as "status" from "tasks" as "t" inner join "task_statuses" as "ts" on "t"."status_id" = "ts"."id" inner join "task_to_group" as "ttg" on "t"."id" = "ttg"."task_id" where "ttg"."group_id" = $1 and "ts"."name" in ($2, $3) order by "t"."id" asc',
+        parameters: [1, 'NOT_STARTED', 'IN_PROGRESS'],
+      },
+    ]);
+  });
+
+  it('builds SQL for ensureTaskInInbox', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      { rows: [{ id: 1, name: 'Inbox', user_id: 4 }] },
+      { rows: [{ group_id: 1, task_id: 10 }] },
+    ]);
+    const repository = new GroupInboxReadRepositoryKysely(db);
+
+    await repository.ensureTaskInInbox({ userId: 4, taskId: 10 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select "g"."id" as "id", "g"."user_id" as "user_id", "g"."name" as "name" from "groups" as "g" left join "task_to_group" as "ttg" on "ttg"."group_id" = "g"."id" where "g"."name" = $1 and "g"."user_id" = $2',
+        parameters: ['IN_BOX', 4],
+      },
+      {
+        sql: 'select from "task_to_group" where "group_id" = $1 and "task_id" = $2',
+        parameters: [1, 10],
+      },
+    ]);
+  });
+});

--- a/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/read/groups.read-repository.kysely.test.ts
+++ b/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/read/groups.read-repository.kysely.test.ts
@@ -1,0 +1,122 @@
+import { GroupStatus } from '@big-d/api-contracts';
+import { GroupsReadRepositoryKysely } from './groups.read-repository.kysely';
+import { createSqlCaptureDb, serializeQueries } from '../__tests__/kysely-test-utils';
+
+describe('GroupsReadRepositoryKysely', () => {
+  it('builds SQL for getByName', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      {
+        rows: [
+          {
+            id: 5,
+            name: 'Work',
+            description: null,
+            user_id: 2,
+            progress: 0,
+            status: GroupStatus.NOT_STARTED,
+          },
+        ],
+      },
+    ]);
+    const repository = new GroupsReadRepositoryKysely(db);
+
+    await repository.getByName({ name: 'Work', userId: 2 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select "g"."id" as "id", "g"."user_id" as "user_id", "g"."description" as "description", "g"."name" as "name", "gs"."name" as "status", "g"."progress" as "progress" from "groups" as "g" inner join "group_statuses" as "gs" on "g"."status_id" = "gs"."id" where "g"."name" not in ($1) and "g"."name" = $2 and "g"."user_id" = $3',
+        parameters: ['IN_BOX', 'Work', 2],
+      },
+    ]);
+  });
+
+  it('builds SQL for getGroupById', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      {
+        rows: [
+          {
+            id: 5,
+            name: 'Work',
+            description: null,
+            user_id: 7,
+            progress: 0,
+            status: GroupStatus.NOT_STARTED,
+          },
+        ],
+      },
+    ]);
+    const repository = new GroupsReadRepositoryKysely(db);
+
+    await repository.getGroupById({ groupId: 5, userId: 7 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select "g"."id" as "id", "g"."user_id" as "user_id", "g"."description" as "description", "g"."name" as "name", "gs"."name" as "status", "g"."progress" as "progress" from "groups" as "g" inner join "group_statuses" as "gs" on "g"."status_id" = "gs"."id" where "g"."name" not in ($1) and "g"."id" = $2 and "g"."user_id" = $3',
+        parameters: ['IN_BOX', 5, 7],
+      },
+    ]);
+  });
+
+  it('builds SQL for getGroupWithTasksById', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      {
+        rows: [
+          {
+            id: 5,
+            name: 'Work',
+            description: null,
+            user_id: 7,
+            progress: 0,
+            status: GroupStatus.NOT_STARTED,
+          },
+        ],
+      },
+      {
+        rows: [
+          {
+            id: 1,
+            user_id: 7,
+            name: 'Task',
+            description: null,
+            priority: 1,
+            weight: 1,
+            cancel_reason: null,
+            start_date: null,
+            end_date: null,
+            deadline: null,
+            recurrence: null,
+            status: 'NOT_STARTED',
+          },
+        ],
+      },
+    ]);
+    const repository = new GroupsReadRepositoryKysely(db);
+
+    await repository.getGroupWithTasksById({ groupId: 5, userId: 7 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select "g"."id" as "id", "g"."user_id" as "user_id", "g"."description" as "description", "g"."name" as "name", "gs"."name" as "status", "g"."progress" as "progress" from "groups" as "g" inner join "group_statuses" as "gs" on "g"."status_id" = "gs"."id" where "g"."name" not in ($1) and "g"."id" = $2 and "g"."user_id" = $3',
+        parameters: ['IN_BOX', 5, 7],
+      },
+      {
+        sql: 'select "t"."id" as "id", "t"."user_id" as "user_id", "t"."name" as "name", "t"."description" as "description", "t"."priority" as "priority", "t"."weight" as "weight", "t"."cancel_reason" as "cancel_reason", "t"."start_date" as "start_date", "t"."end_date" as "end_date", "t"."deadline" as "deadline", "t"."recurrence" as "recurrence", "ts"."name" as "status" from "tasks" as "t" inner join "task_statuses" as "ts" on "t"."status_id" = "ts"."id" inner join "task_to_group" as "ttg" on "t"."id" = "ttg"."task_id" where "ttg"."group_id" = $1 order by "ttg"."position" asc',
+        parameters: [5],
+      },
+    ]);
+  });
+
+  it('builds SQL for ensureTaskInGroup', async () => {
+    const { db, queries } = createSqlCaptureDb([{ rows: [{ group_id: 5, task_id: 11 }] }]);
+    const repository = new GroupsReadRepositoryKysely(db);
+
+    await repository.ensureTaskInGroup({ userId: 7, taskId: 11, groupId: 5 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select from "task_to_group" as "ttg" inner join "groups" as "g" on "g"."id" = "ttg"."group_id" where "ttg"."group_id" = $1 and "ttg"."task_id" = $2 and "g"."user_id" = $3',
+        parameters: [5, 11, 7],
+      },
+    ]);
+  });
+});

--- a/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/read/index.test.ts
+++ b/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/read/index.test.ts
@@ -1,0 +1,13 @@
+import {
+  GroupInboxReadRepositoryKysely,
+  GroupsReadRepositoryKysely,
+  TasksReadRepositoryKysely,
+} from './index';
+
+describe('read repositories index', () => {
+  it('exports read repositories', () => {
+    expect(GroupInboxReadRepositoryKysely).toBeDefined();
+    expect(GroupsReadRepositoryKysely).toBeDefined();
+    expect(TasksReadRepositoryKysely).toBeDefined();
+  });
+});

--- a/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/read/tasks.read-repository.kysely.test.ts
+++ b/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/read/tasks.read-repository.kysely.test.ts
@@ -1,0 +1,68 @@
+import { TaskStatus } from '@big-d/api-contracts';
+import { TasksReadRepositoryKysely } from './tasks.read-repository.kysely';
+import { createSqlCaptureDb, serializeQueries } from '../__tests__/kysely-test-utils';
+
+describe('TasksReadRepositoryKysely', () => {
+  it('builds SQL for getById', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      {
+        rows: [
+          {
+            id: 3,
+            user_id: 9,
+            name: 'Task',
+            description: 'desc',
+            priority: 1,
+            weight: 2,
+            cancel_reason: null,
+            start_date: null,
+            end_date: null,
+            deadline: null,
+            recurrence: null,
+            status: TaskStatus.NOT_STARTED,
+          },
+        ],
+      },
+    ]);
+    const repository = new TasksReadRepositoryKysely(db);
+
+    await repository.getById({ userId: 9, id: 3 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select "t"."id" as "id", "t"."user_id" as "user_id", "t"."name" as "name", "t"."description" as "description", "t"."priority" as "priority", "t"."weight" as "weight", "t"."cancel_reason" as "cancel_reason", "t"."start_date" as "start_date", "t"."end_date" as "end_date", "t"."deadline" as "deadline", "t"."recurrence" as "recurrence", "ts"."name" as "status" from "tasks" as "t" inner join "task_statuses" as "ts" on "t"."status_id" = "ts"."id" where "t"."id" = $1 and "t"."user_id" = $2',
+        parameters: [3, 9],
+      },
+    ]);
+  });
+
+  it('builds SQL for isTaskIntoGroup', async () => {
+    const { db, queries } = createSqlCaptureDb([{ rows: [{ group_id: 2, task_id: 3 }] }]);
+    const repository = new TasksReadRepositoryKysely(db);
+
+    await repository.isTaskIntoGroup({ groupId: 2, taskId: 3 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select from "task_to_group" where "group_id" = $1 and "task_id" = $2',
+        parameters: [2, 3],
+      },
+    ]);
+  });
+
+  it('builds SQL for getTaskToGroupLink', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      { rows: [{ task_id: 3, group_id: 2, position: 1 }] },
+    ]);
+    const repository = new TasksReadRepositoryKysely(db);
+
+    await repository.getTaskToGroupLink({ taskId: 3 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select * from "task_to_group" where "task_id" = $1',
+        parameters: [3],
+      },
+    ]);
+  });
+});

--- a/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/write/group-inbox.write-repository.kysely.test.ts
+++ b/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/write/group-inbox.write-repository.kysely.test.ts
@@ -1,0 +1,25 @@
+import { GroupInboxWriteRepositoryKysely } from './group-inbox.write-repository.kysely';
+import { createSqlCaptureDb, serializeQueries } from '../__tests__/kysely-test-utils';
+
+describe('GroupInboxWriteRepositoryKysely', () => {
+  it('builds SQL for createInbox', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      { rows: [{ id: 2, name: 'IN_PROGRESS' }] },
+      { rows: [{ id: 1, name: 'IN_BOX', user_id: 11 }] },
+    ]);
+    const repository = new GroupInboxWriteRepositoryKysely(db);
+
+    await repository.createInbox({ userId: 11 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select "id", "name" from "group_statuses" where "name" = $1',
+        parameters: ['IN_PROGRESS'],
+      },
+      {
+        sql: 'insert into "groups" ("name", "user_id", "status_id") values ($1, $2, $3) returning "id", "name", "user_id"',
+        parameters: ['IN_BOX', 11, 2],
+      },
+    ]);
+  });
+});

--- a/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/write/group.write-repository.kysely.test.ts
+++ b/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/write/group.write-repository.kysely.test.ts
@@ -1,0 +1,165 @@
+import { TaskStatus } from '@big-d/api-contracts';
+import { TaskView } from '@/modules/tasks/application/dto/task.view';
+import { GroupWriteRepositoryKysely } from './group.write-repository.kysely';
+import { createSqlCaptureDb, serializeQueries } from '../__tests__/kysely-test-utils';
+import { Group, GroupWithTasks } from '@/modules/tasks/domain/aggregates/group';
+
+describe('GroupWriteRepositoryKysely', () => {
+  it('builds SQL for getGroupById', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      {
+        rows: [
+          {
+            id: 5,
+            name: 'Work',
+            description: null,
+            user_id: 7,
+            progress: 0,
+            status: 'NOT_STARTED',
+          },
+        ],
+      },
+      {
+        rows: [
+          {
+            id: 1,
+            user_id: 7,
+            name: 'Task',
+            description: null,
+            priority: 1,
+            weight: 1,
+            cancel_reason: null,
+            start_date: null,
+            end_date: null,
+            deadline: null,
+            recurrence: null,
+            status: 'NOT_STARTED',
+          },
+        ],
+      },
+    ]);
+    const repository = new GroupWriteRepositoryKysely(db);
+
+    await repository.getGroupById({ groupId: 5, userId: 7 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select "g"."id" as "id", "g"."user_id" as "user_id", "g"."description" as "description", "g"."name" as "name", "gs"."name" as "status", "g"."progress" as "progress" from "groups" as "g" inner join "group_statuses" as "gs" on "g"."status_id" = "gs"."id" where "g"."name" not in ($1) and "g"."id" = $2 and "g"."user_id" = $3',
+        parameters: ['IN_BOX', 5, 7],
+      },
+      {
+        sql: 'select "t"."id" as "id", "t"."user_id" as "user_id", "t"."name" as "name", "t"."description" as "description", "t"."priority" as "priority", "t"."weight" as "weight", "t"."cancel_reason" as "cancel_reason", "t"."start_date" as "start_date", "t"."end_date" as "end_date", "t"."deadline" as "deadline", "t"."recurrence" as "recurrence", "ts"."name" as "status" from "tasks" as "t" inner join "task_statuses" as "ts" on "t"."status_id" = "ts"."id" inner join "task_to_group" as "ttg" on "t"."id" = "ttg"."task_id" where "ttg"."group_id" = $1 order by "ttg"."position" asc',
+        parameters: [5],
+      },
+    ]);
+  });
+
+  it('builds SQL for createGroup', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      { rows: [{ id: 1, name: 'NOT_STARTED' }] },
+      { rows: [{ id: 5, name: 'Group', user_id: 3, progress: 0, description: 'Desc' }] },
+    ]);
+    const repository = new GroupWriteRepositoryKysely(db);
+    const group = {
+      name: 'Group',
+      userId: 3,
+      description: 'Desc',
+    } as unknown as Group;
+
+    await repository.createGroup(group);
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select "id", "name" from "group_statuses" where "name" = $1',
+        parameters: ['NOT_STARTED'],
+      },
+      {
+        sql: 'insert into "groups" ("name", "user_id", "description", "status_id") values ($1, $2, $3, $4) returning "id", "name", "user_id", "progress", "description"',
+        parameters: ['Group', 3, 'Desc', 1],
+      },
+    ]);
+  });
+
+  it('builds SQL for replaceGroupWithTasks', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      { rows: [], numAffectedRows: BigInt(1) },
+      { rows: [], numAffectedRows: BigInt(2) },
+      { rows: [], numAffectedRows: BigInt(1) },
+      { rows: [], numAffectedRows: BigInt(1) },
+      { rows: [], numAffectedRows: BigInt(2) },
+    ]);
+    const repository = new GroupWriteRepositoryKysely(db);
+    const tasks = [
+      TaskView.restore({
+        id: 10,
+        userId: 3,
+        name: 'Task 1',
+        description: 'Desc 1',
+        priority: 1,
+        weight: 2,
+        status: TaskStatus.NOT_STARTED,
+        startDate: '2024-01-01',
+        deadline: '2024-01-02',
+        recurrence: 'daily',
+      }),
+      TaskView.restore({
+        id: 11,
+        userId: 3,
+        name: 'Task 2',
+        description: 'Desc 2',
+        priority: 2,
+        weight: 3,
+        status: TaskStatus.NOT_STARTED,
+        startDate: '2024-02-01',
+        deadline: '2024-02-02',
+        recurrence: 'weekly',
+      }),
+    ];
+    const group = {
+      id: 5,
+      userId: 3,
+      name: 'New',
+      description: 'Updated',
+      tasks,
+    } as unknown as GroupWithTasks;
+
+    await repository.replaceGroupWithTasks(group);
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'update "groups" set "name" = $1, "description" = $2 where "id" = $3 and "user_id" = $4 and "name" not in ($5)',
+        parameters: ['New', 'Updated', 5, 3, 'IN_BOX'],
+      },
+      {
+        sql: 'delete from "task_to_group" as "ttg" where "ttg"."group_id" = $1',
+        parameters: [5],
+      },
+      {
+        sql: 'update "tasks" set "name" = $1, "description" = $2, "priority" = $3, "start_date" = $4, "deadline" = $5, "weight" = $6, "recurrence" = $7 where "id" = $8 and "user_id" = $9',
+        parameters: ['Task 1', 'Desc 1', 1, '2024-01-01', '2024-01-02', 2, 'daily', 10, 3],
+      },
+      {
+        sql: 'update "tasks" set "name" = $1, "description" = $2, "priority" = $3, "start_date" = $4, "deadline" = $5, "weight" = $6, "recurrence" = $7 where "id" = $8 and "user_id" = $9',
+        parameters: ['Task 2', 'Desc 2', 2, '2024-02-01', '2024-02-02', 3, 'weekly', 11, 3],
+      },
+      {
+        sql: 'insert into "task_to_group" ("task_id", "group_id", "position") values ($1, $2, $3), ($4, $5, $6)',
+        parameters: [10, 5, 0, 11, 5, 1],
+      },
+    ]);
+  });
+
+  it('builds SQL for deleteById', async () => {
+    const { db, queries } = createSqlCaptureDb([{ rows: [], numAffectedRows: BigInt(1) }]);
+    const repository = new GroupWriteRepositoryKysely(db);
+
+    await repository.deleteById({ groupId: 5, userId: 3 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'delete from "groups" as "g" where "g"."id" = $1 and "g"."user_id" = $2 and "g"."name" not in ($3)',
+        parameters: [5, 3, 'IN_BOX'],
+      },
+    ]);
+  });
+});

--- a/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/write/index.test.ts
+++ b/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/write/index.test.ts
@@ -1,0 +1,13 @@
+import {
+  GroupInboxWriteRepositoryKysely,
+  GroupWriteRepositoryKysely,
+  TasksWriteRepositoryKysely,
+} from './index';
+
+describe('write repositories index', () => {
+  it('exports write repositories', () => {
+    expect(GroupInboxWriteRepositoryKysely).toBeDefined();
+    expect(GroupWriteRepositoryKysely).toBeDefined();
+    expect(TasksWriteRepositoryKysely).toBeDefined();
+  });
+});

--- a/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/write/tasks.write-repository.kysely.test.ts
+++ b/apps/goal-service/src/modules/tasks/infrastructure/persistence/kysely/repositories/write/tasks.write-repository.kysely.test.ts
@@ -1,0 +1,182 @@
+import { TaskStatus } from '@big-d/api-contracts';
+import { TasksWriteRepositoryKysely } from './tasks.write-repository.kysely';
+import { createSqlCaptureDb, serializeQueries } from '../__tests__/kysely-test-utils';
+import { Task } from '@/modules/tasks/domain';
+
+describe('TasksWriteRepositoryKysely', () => {
+  const fakeTask = {
+    id: 4,
+    userId: 2,
+    name: 'Task',
+    description: 'Desc',
+    priority: 1,
+    weight: 2,
+    cancelReason: null,
+    startDate: null,
+    endDate: null,
+    deadline: null,
+    status: TaskStatus.NOT_STARTED,
+    recurrence: null,
+  } as unknown as Task;
+
+  it('builds SQL for getTaskById', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      {
+        rows: [
+          {
+            id: 4,
+            user_id: 2,
+            name: 'Task',
+            description: 'Desc',
+            priority: 1,
+            weight: 2,
+            cancel_reason: null,
+            start_date: null,
+            end_date: null,
+            deadline: null,
+            recurrence: null,
+            status: TaskStatus.NOT_STARTED,
+          },
+        ],
+      },
+    ]);
+    const repository = new TasksWriteRepositoryKysely(db);
+
+    await repository.getTaskById({ taskId: 4, userId: 2 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select "t"."id" as "id", "t"."user_id" as "user_id", "t"."name" as "name", "t"."description" as "description", "t"."priority" as "priority", "t"."weight" as "weight", "t"."cancel_reason" as "cancel_reason", "t"."start_date" as "start_date", "t"."end_date" as "end_date", "t"."deadline" as "deadline", "t"."recurrence" as "recurrence", "ts"."name" as "status" from "tasks" as "t" inner join "task_statuses" as "ts" on "t"."status_id" = "ts"."id" where "t"."id" = $1 and "t"."user_id" = $2',
+        parameters: [4, 2],
+      },
+    ]);
+  });
+
+  it('builds SQL for createTask', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      { rows: [{ statusId: 1, statusName: 'NOT_STARTED' }] },
+      {
+        rows: [
+          {
+            id: 4,
+            user_id: 2,
+            name: 'Task',
+            description: 'Desc',
+            priority: 1,
+            weight: 2,
+            cancel_reason: null,
+            start_date: null,
+            end_date: null,
+            deadline: null,
+            recurrence: null,
+          },
+        ],
+      },
+    ]);
+    const repository = new TasksWriteRepositoryKysely(db);
+
+    await repository.createTask(fakeTask);
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select "id" as "statusId", "name" as "statusName" from "task_statuses" where "task_statuses"."name" = $1',
+        parameters: ['NOT_STARTED'],
+      },
+      {
+        sql: 'insert into "tasks" ("cancel_reason", "name", "deadline", "end_date", "start_date", "description", "user_id", "status_id") values ($1, $2, $3, $4, $5, $6, $7, $8) returning "id", "user_id", "name", "description", "priority", "weight", "cancel_reason", "start_date", "end_date", "deadline", "recurrence"',
+        parameters: [null, 'Task', null, null, null, 'Desc', 2, 1],
+      },
+    ]);
+  });
+
+  it('builds SQL for replaceTask', async () => {
+    const { db, queries } = createSqlCaptureDb([{ rows: [] }]);
+    const repository = new TasksWriteRepositoryKysely(db);
+
+    await repository.replaceTask(fakeTask);
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'update "tasks" set "name" = $1, "description" = $2, "priority" = $3, "weight" = $4, "start_date" = $5, "end_date" = $6, "deadline" = $7, "recurrence" = $8 where "id" = $9 and "user_id" = $10 returning "id", "user_id", "name", "description", "priority", "weight", "cancel_reason", "start_date", "end_date", "deadline", "recurrence"',
+        parameters: ['Task', 'Desc', 1, 2, null, null, null, null, 4, 2],
+      },
+    ]);
+  });
+
+  it('builds SQL for addTaskToGroup', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      { rows: [{ count: 3 }] },
+      { rows: [], numAffectedRows: BigInt(1) },
+    ]);
+    const repository = new TasksWriteRepositoryKysely(db);
+
+    await repository.addTaskToGroup({ groupId: 5, taskId: 10 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select count("task_id") as "count" from "task_to_group" where "group_id" = $1',
+        parameters: [5],
+      },
+      {
+        sql: 'insert into "task_to_group" ("group_id", "task_id", "position") values ($1, $2, $3)',
+        parameters: [5, 10, 3],
+      },
+    ]);
+  });
+
+  it('builds SQL for removeTaskFromGroup', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      { rows: [{ position: 2, group_id: 5 }] },
+      { rows: [], numAffectedRows: BigInt(1) },
+    ]);
+    const repository = new TasksWriteRepositoryKysely(db);
+
+    await repository.removeTaskFromGroup({ taskId: 10 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'delete from "task_to_group" where "task_id" = $1 returning "position", "group_id"',
+        parameters: [10],
+      },
+      {
+        sql: 'update "task_to_group" set "position" = "position" - $1 where "group_id" = $2 and "position" > $3',
+        parameters: [1, 5, 2],
+      },
+    ]);
+  });
+
+  it('builds SQL for changeTaskStatus', async () => {
+    const { db, queries } = createSqlCaptureDb([
+      { rows: [{ statusId: 3 }] },
+      { rows: [], numAffectedRows: BigInt(1) },
+    ]);
+    const repository = new TasksWriteRepositoryKysely(db);
+
+    await repository.changeTaskStatus(fakeTask);
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'select "id" as "statusId" from "task_statuses" as "ts" where "ts"."name" = $1',
+        parameters: ['NOT_STARTED'],
+      },
+      {
+        sql: 'update "tasks" set "status_id" = $1 where "id" = $2 and "user_id" = $3',
+        parameters: [3, 4, 2],
+      },
+    ]);
+  });
+
+  it('builds SQL for deleteTask', async () => {
+    const { db, queries } = createSqlCaptureDb([{ rows: [], numAffectedRows: BigInt(1) }]);
+    const repository = new TasksWriteRepositoryKysely(db);
+
+    await repository.deleteTask({ userId: 2, taskId: 4 });
+
+    expect(serializeQueries(queries)).toEqual([
+      {
+        sql: 'delete from "tasks" where "id" = $1 and "user_id" = $2',
+        parameters: [4, 2],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure repository code generates the expected Kysely SQL and parameters for all read/write task repositories and helper queries. 
- Provide a reusable SQL-capture test harness so the queries can be asserted without a real DB connection.

### Description
- Add SQL capture test utilities `__tests__/kysely-test-utils.ts` that provide a fake Kysely dialect/driver to record compiled queries. 
- Add unit tests for helpers and base repository error handling in `helpers/helpers.test.ts` and `base-tasks.repository.test.ts` validating compiled SQL and error wrapping. 
- Add read-repository SQL expectation tests for `group-inbox`, `groups`, and `tasks` under `read/*.test.ts` that assert both SQL text and parameters. 
- Add write-repository SQL expectation tests for `group-inbox`, `group`, and `tasks` under `write/*.test.ts` and small index export tests under `read/index.test.ts` and `write/index.test.ts`.

### Testing
- No automated test run was performed as part of this change (tests were added but not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969fb24f45083289de0b76c397c8ea5)