### PR TITLE
test: expand RMQ controller coverage and centralize repository mocks

### DIFF
--- a/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/groups-inbox.rmq.controller.test.ts
+++ b/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/groups-inbox.rmq.controller.test.ts
@@ -13,20 +13,13 @@ import {
 } from '@shared/__tests__';
 import { getGroupInboxView, getTaskView } from '@shared/__tests__/entities';
 import { initTestEnvironment } from '@/../jest.setup';
-import {
-  inboxReadRepoMock,
-  inboxWriteRepoMock,
-} from '@shared/__tests__/repository-mocks';
+import { inboxReadRepoMock, inboxWriteRepoMock } from '@shared/__tests__/repository-mocks';
 
 initTestEnvironment();
 describe('GroupsInboxRmqController (rmq e2e)', () => {
   let ms: INestMicroservice;
   let client: ClientProxy;
   let sendMessage: ReturnType<typeof sendMessageBuilder>;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
 
   beforeAll(async () => {
     const moduleRef = await createTestingModule()

--- a/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/groups-inbox.rmq.controller.test.ts
+++ b/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/groups-inbox.rmq.controller.test.ts
@@ -1,7 +1,3 @@
-import {
-  GroupInboxReadRepository,
-  GroupInboxWriteRepository,
-} from '@/modules/tasks/application/ports';
 import { GroupsToken } from '@/modules/tasks/tokens';
 import { GoalCreateInboxGroup, GoalGetGroupInBox, RmqErrorKind } from '@big-d/api-contracts';
 import { exceptionCode } from '@big-d/exceptions';
@@ -17,21 +13,20 @@ import {
 } from '@shared/__tests__';
 import { getGroupInboxView, getTaskView } from '@shared/__tests__/entities';
 import { initTestEnvironment } from '@/../jest.setup';
+import {
+  inboxReadRepoMock,
+  inboxWriteRepoMock,
+} from '@shared/__tests__/repository-mocks';
 
 initTestEnvironment();
-const inboxWriteRepoMock: Record<keyof GroupInboxWriteRepository, jest.Mock> = {
-  createInbox: jest.fn(),
-};
-
-const inboxReadRepoMock: Record<keyof GroupInboxReadRepository, jest.Mock> = {
-  getInboxWithTasksByUserId: jest.fn(),
-  ensureTaskInInbox: jest.fn(),
-};
-
 describe('GroupsInboxRmqController (rmq e2e)', () => {
   let ms: INestMicroservice;
   let client: ClientProxy;
   let sendMessage: ReturnType<typeof sendMessageBuilder>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   beforeAll(async () => {
     const moduleRef = await createTestingModule()

--- a/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/groups.rmq.controller.test.ts
+++ b/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/groups.rmq.controller.test.ts
@@ -1,8 +1,3 @@
-import {
-  GroupsReadRepository,
-  GroupsWriteRepository,
-  TasksWriteRepository,
-} from '@/modules/tasks/application/ports';
 import { Group, GroupWithTasks } from '@/modules/tasks/domain/aggregates/group';
 import { GroupReadKyselyMapper } from '@/modules/tasks/infrastructure/persistence/kysely/mappers/groups.read-mapper';
 import { GroupWriteKyselyMapper } from '@/modules/tasks/infrastructure/persistence/kysely/mappers/groups.write-mapper';
@@ -27,37 +22,21 @@ import {
 } from '@shared/__tests__';
 import { getGroupRaw, getGroupWithTasks, getTask, getTaskView } from '@shared/__tests__/entities';
 import { initTestEnvironment } from '@/../jest.setup';
+import {
+  groupReadRepoMock,
+  groupWriteRepoMock,
+  tasksWriteRepoMock,
+} from '@shared/__tests__/repository-mocks';
 
 initTestEnvironment();
-const groupWriteRepoMock: Record<keyof GroupsWriteRepository, jest.Mock> = {
-  createGroup: jest.fn(),
-  deleteById: jest.fn(),
-  getGroupById: jest.fn(),
-  replaceGroupWithTasks: jest.fn(),
-};
-
-const groupReadRepoMock: Record<keyof GroupsReadRepository, jest.Mock> = {
-  getByName: jest.fn(),
-  getGroupById: jest.fn(),
-  getGroupWithTasksById: jest.fn(),
-  ensureTaskInGroup: jest.fn(),
-  getGroupListWithTasksByUserId: jest.fn(),
-};
-
-const tasksWriteRepoMock: Record<keyof TasksWriteRepository, jest.Mock> = {
-  getTaskById: jest.fn(),
-  createTask: jest.fn(),
-  deleteTask: jest.fn(),
-  changeTaskStatus: jest.fn(),
-  replaceTask: jest.fn(),
-  addTaskToGroup: jest.fn(),
-  removeTaskFromGroup: jest.fn(),
-};
-
 describe('GroupsRmqController (rmq e2e)', () => {
   let ms: INestMicroservice;
   let client: ClientProxy;
   let sendMessage: ReturnType<typeof sendMessageBuilder>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   beforeAll(async () => {
     const moduleRef = await createTestingModule()
@@ -83,7 +62,8 @@ describe('GroupsRmqController (rmq e2e)', () => {
     await ms.close();
   });
 
-  test(`${GoalGetUserGroups.pattern} should return user groups`, async () => {
+  describe(`${GoalGetUserGroups.pattern}`, () => {
+    test('should return user groups', async () => {
     const taskView = getTaskView({ id: 91, userId: 7, name: 'T1', priority: 3, weight: 10 });
     const groupRaw = getGroupRaw({ id: 11, user_id: 7, name: 'Group 1' });
     const groupRawTwo = getGroupRaw({ id: 22, user_id: 7, name: 'Group 2' });
@@ -142,9 +122,11 @@ describe('GroupsRmqController (rmq e2e)', () => {
         },
       ],
     });
+    });
   });
 
-  test(`${GoalCreateGroup.pattern} should work`, async () => {
+  describe(`${GoalCreateGroup.pattern}`, () => {
+    test('should work', async () => {
     const groupRaw = getGroupRaw({ user_id: 1, name: 'G1', description: '<b>hi</b>' });
     groupReadRepoMock.getGroupById.mockResolvedValueOnce(
       GroupReadKyselyMapper.fromRawToWithTaskView({ ...groupRaw, tasks: [] }),
@@ -185,9 +167,9 @@ describe('GroupsRmqController (rmq e2e)', () => {
         tasks: [],
       },
     });
-  });
+    });
 
-  test(`${GoalCreateGroup.pattern} should return not found when group view missing`, async () => {
+    test('should return not found when group view missing', async () => {
     const groupRaw = getGroupRaw({ id: 44, user_id: 2, name: 'Missing view' });
     groupWriteRepoMock.createGroup.mockResolvedValueOnce(
       GroupWriteKyselyMapper.fromRawToAgr(groupRaw),
@@ -218,9 +200,11 @@ describe('GroupsRmqController (rmq e2e)', () => {
       kind: RmqErrorKind.NOT_FOUND,
       details: { groupId: groupRaw.id },
     });
+    });
   });
 
-  test(`${GoalReplaceGroup.pattern} should replace group with tasks`, async () => {
+  describe(`${GoalReplaceGroup.pattern}`, () => {
+    test('should replace group with tasks', async () => {
     const userId = 5;
     const groupId = 12;
     const taskInputOne = {
@@ -330,9 +314,9 @@ describe('GroupsRmqController (rmq e2e)', () => {
         ],
       },
     });
-  });
+    });
 
-  test(`${GoalReplaceGroup.pattern} should throw when group missing`, async () => {
+    test('should throw when group missing', async () => {
     const payload: GoalReplaceGroup.Request = buildPayload({
       data: {
         id: 999,
@@ -365,9 +349,9 @@ describe('GroupsRmqController (rmq e2e)', () => {
       kind: RmqErrorKind.NOT_FOUND,
       details: { groupId: 999 },
     });
-  });
+    });
 
-  test(`${GoalReplaceGroup.pattern} should throw when task is missing`, async () => {
+    test('should throw when task is missing', async () => {
     const userId = 10;
     const groupId = 300;
     const payload: GoalReplaceGroup.Request = buildPayload({
@@ -412,9 +396,9 @@ describe('GroupsRmqController (rmq e2e)', () => {
       kind: RmqErrorKind.NOT_FOUND,
       details: { taskId: 555 },
     });
-  });
+    });
 
-  test(`${GoalReplaceGroup.pattern} should throw when task not in group`, async () => {
+    test('should throw when task not in group', async () => {
     const userId = 10;
     const groupId = 301;
     const payload: GoalReplaceGroup.Request = buildPayload({
@@ -460,9 +444,11 @@ describe('GroupsRmqController (rmq e2e)', () => {
       kind: RmqErrorKind.NOT_FOUND,
       details: { taskId: 556, groupId },
     });
+    });
   });
 
-  test(`${GoalDeleteGroup.pattern} should delete group`, async () => {
+  describe(`${GoalDeleteGroup.pattern}`, () => {
+    test('should delete group', async () => {
     const userId = 50;
     const groupId = 80;
     groupWriteRepoMock.getGroupById.mockResolvedValueOnce(
@@ -487,9 +473,9 @@ describe('GroupsRmqController (rmq e2e)', () => {
       expectTransaction(),
     );
     expect(res).toEqual({ data: true });
-  });
+    });
 
-  test(`${GoalDeleteGroup.pattern} should throw when group missing`, async () => {
+    test('should throw when group missing', async () => {
     const payload: GoalDeleteGroup.Request = buildPayload({
       data: { groupId: 81, userId: 51 },
     });
@@ -512,9 +498,9 @@ describe('GroupsRmqController (rmq e2e)', () => {
       kind: RmqErrorKind.NOT_FOUND,
       details: { groupId: 81 },
     });
-  });
+    });
 
-  test(`${GoalDeleteGroup.pattern} should throw when group has tasks`, async () => {
+    test('should throw when group has tasks', async () => {
     const payload: GoalDeleteGroup.Request = buildPayload({
       data: { groupId: 82, userId: 52 },
     });
@@ -543,9 +529,9 @@ describe('GroupsRmqController (rmq e2e)', () => {
         message: "Group can't be delete if has at least one task",
       },
     });
-  });
+    });
 
-  test(`${GoalDeleteGroup.pattern} should throw on write conflict`, async () => {
+    test('should throw on write conflict', async () => {
     const payload: GoalDeleteGroup.Request = buildPayload({
       data: { groupId: 83, userId: 53 },
     });
@@ -573,6 +559,7 @@ describe('GroupsRmqController (rmq e2e)', () => {
       key: 'GROUP_WRITE_CONFLICT',
       kind: RmqErrorKind.INTERNAL,
       details: { subjectId: 83, message: 'Group could not be deleted' },
+    });
     });
   });
 });

--- a/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/groups.rmq.controller.test.ts
+++ b/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/groups.rmq.controller.test.ts
@@ -34,10 +34,6 @@ describe('GroupsRmqController (rmq e2e)', () => {
   let client: ClientProxy;
   let sendMessage: ReturnType<typeof sendMessageBuilder>;
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   beforeAll(async () => {
     const moduleRef = await createTestingModule()
       .overrideProvider(GroupsToken.WRITE_REPOSITORY)

--- a/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/groups.rmq.controller.test.ts
+++ b/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/groups.rmq.controller.test.ts
@@ -64,502 +64,502 @@ describe('GroupsRmqController (rmq e2e)', () => {
 
   describe(`${GoalGetUserGroups.pattern}`, () => {
     test('should return user groups', async () => {
-    const taskView = getTaskView({ id: 91, userId: 7, name: 'T1', priority: 3, weight: 10 });
-    const groupRaw = getGroupRaw({ id: 11, user_id: 7, name: 'Group 1' });
-    const groupRawTwo = getGroupRaw({ id: 22, user_id: 7, name: 'Group 2' });
-    groupReadRepoMock.getGroupListWithTasksByUserId.mockResolvedValueOnce([
-      GroupReadKyselyMapper.fromRawToWithTaskView({ ...groupRaw, tasks: [taskView] }),
-      GroupReadKyselyMapper.fromRawToWithTaskView({ ...groupRawTwo, tasks: [] }),
-    ]);
-    const payload: GoalGetUserGroups.Request = buildPayload({
-      data: { userId: 7 },
+      const taskView = getTaskView({ id: 91, userId: 7, name: 'T1', priority: 3, weight: 10 });
+      const groupRaw = getGroupRaw({ id: 11, user_id: 7, name: 'Group 1' });
+      const groupRawTwo = getGroupRaw({ id: 22, user_id: 7, name: 'Group 2' });
+      groupReadRepoMock.getGroupListWithTasksByUserId.mockResolvedValueOnce([
+        GroupReadKyselyMapper.fromRawToWithTaskView({ ...groupRaw, tasks: [taskView] }),
+        GroupReadKyselyMapper.fromRawToWithTaskView({ ...groupRawTwo, tasks: [] }),
+      ]);
+      const payload: GoalGetUserGroups.Request = buildPayload({
+        data: { userId: 7 },
+      });
+
+      const res = await sendMessage<GoalGetUserGroups.Response, GoalGetUserGroups.Request>(
+        GoalGetUserGroups.pattern,
+        payload,
+      );
+
+      expect(groupReadRepoMock.getGroupListWithTasksByUserId).toHaveBeenCalledTimes(1);
+      expect(groupReadRepoMock.getGroupListWithTasksByUserId).toHaveBeenCalledWith(
+        { userId: 7 },
+        expectTransaction(),
+      );
+      expect(res).toEqual({
+        data: [
+          {
+            id: groupRaw.id,
+            name: groupRaw.name,
+            description: groupRaw.description,
+            status: groupRaw.status,
+            userId: groupRaw.user_id,
+            progress: groupRaw.progress,
+            tasks: [
+              {
+                id: taskView.id,
+                userId: taskView.userId,
+                name: taskView.name,
+                description: taskView.description,
+                priority: taskView.priority,
+                weight: taskView.weight,
+                cancelReason: taskView.cancelReason,
+                startDate: taskView.startDate,
+                endDate: taskView.endDate,
+                deadline: taskView.deadline,
+                status: taskView.status,
+                recurrence: taskView.recurrence,
+              },
+            ],
+          },
+          {
+            id: groupRawTwo.id,
+            name: groupRawTwo.name,
+            description: groupRawTwo.description,
+            status: groupRawTwo.status,
+            userId: groupRawTwo.user_id,
+            progress: groupRawTwo.progress,
+            tasks: [],
+          },
+        ],
+      });
     });
+  });
 
-    const res = await sendMessage<GoalGetUserGroups.Response, GoalGetUserGroups.Request>(
-      GoalGetUserGroups.pattern,
-      payload,
-    );
+  describe(`${GoalCreateGroup.pattern}`, () => {
+    test('should work', async () => {
+      const groupRaw = getGroupRaw({ user_id: 1, name: 'G1', description: '<b>hi</b>' });
+      groupReadRepoMock.getGroupById.mockResolvedValueOnce(
+        GroupReadKyselyMapper.fromRawToWithTaskView({ ...groupRaw, tasks: [] }),
+      );
+      groupWriteRepoMock.createGroup.mockResolvedValueOnce(
+        GroupWriteKyselyMapper.fromRawToAgr(groupRaw),
+      );
+      const payload: GoalCreateGroup.Request = buildPayload({
+        data: { userId: groupRaw.user_id, name: groupRaw.name, description: groupRaw.description },
+      });
 
-    expect(groupReadRepoMock.getGroupListWithTasksByUserId).toHaveBeenCalledTimes(1);
-    expect(groupReadRepoMock.getGroupListWithTasksByUserId).toHaveBeenCalledWith(
-      { userId: 7 },
-      expectTransaction(),
-    );
-    expect(res).toEqual({
-      data: [
-        {
+      const res = await sendMessage<GoalCreateGroup.Response, GoalCreateGroup.Request>(
+        GoalCreateGroup.pattern,
+        payload,
+      );
+
+      const [[groupArg, trxArg]] = groupWriteRepoMock.createGroup.mock.calls;
+      expect(groupArg).toBeInstanceOf(Group);
+      expect(groupArg.id).toEqual(NaN);
+      expect(groupArg.name).toEqual(groupRaw.name);
+      expect(groupArg.description).toEqual(groupRaw.description);
+      expect(groupArg.status).toEqual(groupRaw.status);
+      expect(groupArg.userId).toEqual(groupRaw.user_id);
+      expect(groupArg.progress).toEqual(groupRaw.progress);
+      expect(trxArg).toEqual(expect.anything());
+      expect(groupReadRepoMock.getGroupById).toHaveBeenCalledWith(
+        { groupId: groupRaw.id, userId: groupRaw.user_id },
+        { trx: expectTransaction() },
+      );
+      expect(res).toEqual({
+        data: {
           id: groupRaw.id,
           name: groupRaw.name,
           description: groupRaw.description,
           status: groupRaw.status,
           userId: groupRaw.user_id,
           progress: groupRaw.progress,
-          tasks: [
-            {
-              id: taskView.id,
-              userId: taskView.userId,
-              name: taskView.name,
-              description: taskView.description,
-              priority: taskView.priority,
-              weight: taskView.weight,
-              cancelReason: taskView.cancelReason,
-              startDate: taskView.startDate,
-              endDate: taskView.endDate,
-              deadline: taskView.deadline,
-              status: taskView.status,
-              recurrence: taskView.recurrence,
-            },
-          ],
-        },
-        {
-          id: groupRawTwo.id,
-          name: groupRawTwo.name,
-          description: groupRawTwo.description,
-          status: groupRawTwo.status,
-          userId: groupRawTwo.user_id,
-          progress: groupRawTwo.progress,
           tasks: [],
         },
-      ],
-    });
-    });
-  });
-
-  describe(`${GoalCreateGroup.pattern}`, () => {
-    test('should work', async () => {
-    const groupRaw = getGroupRaw({ user_id: 1, name: 'G1', description: '<b>hi</b>' });
-    groupReadRepoMock.getGroupById.mockResolvedValueOnce(
-      GroupReadKyselyMapper.fromRawToWithTaskView({ ...groupRaw, tasks: [] }),
-    );
-    groupWriteRepoMock.createGroup.mockResolvedValueOnce(
-      GroupWriteKyselyMapper.fromRawToAgr(groupRaw),
-    );
-    const payload: GoalCreateGroup.Request = buildPayload({
-      data: { userId: groupRaw.user_id, name: groupRaw.name, description: groupRaw.description },
-    });
-
-    const res = await sendMessage<GoalCreateGroup.Response, GoalCreateGroup.Request>(
-      GoalCreateGroup.pattern,
-      payload,
-    );
-
-    const [[groupArg, trxArg]] = groupWriteRepoMock.createGroup.mock.calls;
-    expect(groupArg).toBeInstanceOf(Group);
-    expect(groupArg.id).toEqual(NaN);
-    expect(groupArg.name).toEqual(groupRaw.name);
-    expect(groupArg.description).toEqual(groupRaw.description);
-    expect(groupArg.status).toEqual(groupRaw.status);
-    expect(groupArg.userId).toEqual(groupRaw.user_id);
-    expect(groupArg.progress).toEqual(groupRaw.progress);
-    expect(trxArg).toEqual(expect.anything());
-    expect(groupReadRepoMock.getGroupById).toHaveBeenCalledWith(
-      { groupId: groupRaw.id, userId: groupRaw.user_id },
-      { trx: expectTransaction() },
-    );
-    expect(res).toEqual({
-      data: {
-        id: groupRaw.id,
-        name: groupRaw.name,
-        description: groupRaw.description,
-        status: groupRaw.status,
-        userId: groupRaw.user_id,
-        progress: groupRaw.progress,
-        tasks: [],
-      },
-    });
+      });
     });
 
     test('should return not found when group view missing', async () => {
-    const groupRaw = getGroupRaw({ id: 44, user_id: 2, name: 'Missing view' });
-    groupWriteRepoMock.createGroup.mockResolvedValueOnce(
-      GroupWriteKyselyMapper.fromRawToAgr(groupRaw),
-    );
-    groupReadRepoMock.getGroupById.mockResolvedValueOnce(null);
-    const payload: GoalCreateGroup.Request = buildPayload({
-      data: { userId: groupRaw.user_id, name: groupRaw.name, description: groupRaw.description },
-    });
-
-    let error: unknown;
-    try {
-      await sendMessage<GoalCreateGroup.Response, GoalCreateGroup.Request>(
-        GoalCreateGroup.pattern,
-        payload,
+      const groupRaw = getGroupRaw({ id: 44, user_id: 2, name: 'Missing view' });
+      groupWriteRepoMock.createGroup.mockResolvedValueOnce(
+        GroupWriteKyselyMapper.fromRawToAgr(groupRaw),
       );
-    } catch (err) {
-      error = err;
-    }
+      groupReadRepoMock.getGroupById.mockResolvedValueOnce(null);
+      const payload: GoalCreateGroup.Request = buildPayload({
+        data: { userId: groupRaw.user_id, name: groupRaw.name, description: groupRaw.description },
+      });
 
-    expect(groupWriteRepoMock.createGroup).toHaveBeenCalledTimes(1);
-    expect(groupReadRepoMock.getGroupById).toHaveBeenCalledWith(
-      { groupId: groupRaw.id, userId: groupRaw.user_id },
-      { trx: expectTransaction() },
-    );
-    expect(unwrapRpcError(error)).toMatchObject({
-      code: exceptionCode.groupNotFound.code,
-      key: 'GROUP_NOT_FOUND',
-      kind: RmqErrorKind.NOT_FOUND,
-      details: { groupId: groupRaw.id },
-    });
+      let error: unknown;
+      try {
+        await sendMessage<GoalCreateGroup.Response, GoalCreateGroup.Request>(
+          GoalCreateGroup.pattern,
+          payload,
+        );
+      } catch (err) {
+        error = err;
+      }
+
+      expect(groupWriteRepoMock.createGroup).toHaveBeenCalledTimes(1);
+      expect(groupReadRepoMock.getGroupById).toHaveBeenCalledWith(
+        { groupId: groupRaw.id, userId: groupRaw.user_id },
+        { trx: expectTransaction() },
+      );
+      expect(unwrapRpcError(error)).toMatchObject({
+        code: exceptionCode.groupNotFound.code,
+        key: 'GROUP_NOT_FOUND',
+        kind: RmqErrorKind.NOT_FOUND,
+        details: { groupId: groupRaw.id },
+      });
     });
   });
 
   describe(`${GoalReplaceGroup.pattern}`, () => {
     test('should replace group with tasks', async () => {
-    const userId = 5;
-    const groupId = 12;
-    const taskInputOne = {
-      id: 101,
-      name: 'Task A',
-      description: 'desc-a',
-      priority: 2,
-      weight: 10,
-      startDate: '2024-01-01T00:00:00.000Z',
-      deadline: '2024-02-01T00:00:00.000Z',
-      recurrence: 'daily',
-    };
-    const taskInputTwo = {
-      id: 202,
-      name: 'Task B',
-      priority: 3,
-      weight: 20,
-    };
-    const groupWithTasks = getGroupWithTasks({ id: groupId, user_id: userId, name: 'Old' });
-    const restoredTaskOne = getTask({ id: taskInputOne.id, userId });
-    const restoredTaskTwo = getTask({ id: taskInputTwo.id, userId });
-    const responseTask = getTaskView({ id: taskInputOne.id, userId, name: taskInputOne.name });
+      const userId = 5;
+      const groupId = 12;
+      const taskInputOne = {
+        id: 101,
+        name: 'Task A',
+        description: 'desc-a',
+        priority: 2,
+        weight: 10,
+        startDate: '2024-01-01T00:00:00.000Z',
+        deadline: '2024-02-01T00:00:00.000Z',
+        recurrence: 'daily',
+      };
+      const taskInputTwo = {
+        id: 202,
+        name: 'Task B',
+        priority: 3,
+        weight: 20,
+      };
+      const groupWithTasks = getGroupWithTasks({ id: groupId, user_id: userId, name: 'Old' });
+      const restoredTaskOne = getTask({ id: taskInputOne.id, userId });
+      const restoredTaskTwo = getTask({ id: taskInputTwo.id, userId });
+      const responseTask = getTaskView({ id: taskInputOne.id, userId, name: taskInputOne.name });
 
-    groupWriteRepoMock.getGroupById.mockResolvedValueOnce(groupWithTasks);
-    tasksWriteRepoMock.getTaskById
-      .mockResolvedValueOnce(restoredTaskOne)
-      .mockResolvedValueOnce(restoredTaskTwo);
-    groupReadRepoMock.ensureTaskInGroup.mockResolvedValue(true);
-    groupWriteRepoMock.replaceGroupWithTasks.mockResolvedValueOnce(undefined);
-    groupReadRepoMock.getGroupWithTasksById.mockResolvedValueOnce(
-      GroupReadKyselyMapper.fromRawToWithTaskView({
-        ...getGroupRaw({ id: groupId, user_id: userId, name: 'Updated', description: 'New' }),
-        tasks: [responseTask],
-      }),
-    );
+      groupWriteRepoMock.getGroupById.mockResolvedValueOnce(groupWithTasks);
+      tasksWriteRepoMock.getTaskById
+        .mockResolvedValueOnce(restoredTaskOne)
+        .mockResolvedValueOnce(restoredTaskTwo);
+      groupReadRepoMock.ensureTaskInGroup.mockResolvedValue(true);
+      groupWriteRepoMock.replaceGroupWithTasks.mockResolvedValueOnce(undefined);
+      groupReadRepoMock.getGroupWithTasksById.mockResolvedValueOnce(
+        GroupReadKyselyMapper.fromRawToWithTaskView({
+          ...getGroupRaw({ id: groupId, user_id: userId, name: 'Updated', description: 'New' }),
+          tasks: [responseTask],
+        }),
+      );
 
-    const payload: GoalReplaceGroup.Request = buildPayload({
-      data: {
-        id: groupId,
-        userId,
-        name: 'Updated',
-        description: 'New',
-        tasks: [taskInputOne, taskInputTwo],
-      },
-    });
+      const payload: GoalReplaceGroup.Request = buildPayload({
+        data: {
+          id: groupId,
+          userId,
+          name: 'Updated',
+          description: 'New',
+          tasks: [taskInputOne, taskInputTwo],
+        },
+      });
 
-    const res = await sendMessage<GoalReplaceGroup.Response, GoalReplaceGroup.Request>(
-      GoalReplaceGroup.pattern,
-      payload,
-    );
+      const res = await sendMessage<GoalReplaceGroup.Response, GoalReplaceGroup.Request>(
+        GoalReplaceGroup.pattern,
+        payload,
+      );
 
-    expect(groupWriteRepoMock.getGroupById).toHaveBeenCalledWith(
-      { groupId, userId },
-      expectTransaction(),
-    );
-    expect(tasksWriteRepoMock.getTaskById).toHaveBeenCalledWith(
-      { taskId: taskInputOne.id, userId },
-      expectTransaction(),
-    );
-    expect(tasksWriteRepoMock.getTaskById).toHaveBeenCalledWith(
-      { taskId: taskInputTwo.id, userId },
-      expectTransaction(),
-    );
-    expect(groupReadRepoMock.ensureTaskInGroup).toHaveBeenCalledWith(
-      { taskId: taskInputOne.id, groupId, userId },
-      expectTransaction(),
-    );
-    expect(groupReadRepoMock.ensureTaskInGroup).toHaveBeenCalledWith(
-      { taskId: taskInputTwo.id, groupId, userId },
-      expectTransaction(),
-    );
-    const [[replacedGroupArg, trxArg]] = groupWriteRepoMock.replaceGroupWithTasks.mock.calls;
-    expect(replacedGroupArg).toBeInstanceOf(GroupWithTasks);
-    expect(replacedGroupArg.id).toBe(groupId);
-    expect(replacedGroupArg.userId).toBe(userId);
-    expect(replacedGroupArg.name).toBe('Updated');
-    expect(replacedGroupArg.description).toBe('New');
-    expect(replacedGroupArg.tasks).toHaveLength(2);
-    expect(trxArg).toEqual(expect.anything());
-    expect(groupReadRepoMock.getGroupWithTasksById).toHaveBeenCalledWith(
-      { groupId, userId },
-      { trx: expectTransaction(), throwError: true },
-    );
-    expect(res).toEqual({
-      data: {
-        id: groupId,
-        name: 'Updated',
-        description: 'New',
-        status: getGroupRaw().status,
-        userId,
-        progress: getGroupRaw().progress,
-        tasks: [
-          {
-            id: responseTask.id,
-            userId: responseTask.userId,
-            name: responseTask.name,
-            description: responseTask.description,
-            priority: responseTask.priority,
-            weight: responseTask.weight,
-            cancelReason: responseTask.cancelReason,
-            startDate: responseTask.startDate,
-            endDate: responseTask.endDate,
-            deadline: responseTask.deadline,
-            status: responseTask.status,
-            recurrence: responseTask.recurrence,
-          },
-        ],
-      },
-    });
+      expect(groupWriteRepoMock.getGroupById).toHaveBeenCalledWith(
+        { groupId, userId },
+        expectTransaction(),
+      );
+      expect(tasksWriteRepoMock.getTaskById).toHaveBeenCalledWith(
+        { taskId: taskInputOne.id, userId },
+        expectTransaction(),
+      );
+      expect(tasksWriteRepoMock.getTaskById).toHaveBeenCalledWith(
+        { taskId: taskInputTwo.id, userId },
+        expectTransaction(),
+      );
+      expect(groupReadRepoMock.ensureTaskInGroup).toHaveBeenCalledWith(
+        { taskId: taskInputOne.id, groupId, userId },
+        expectTransaction(),
+      );
+      expect(groupReadRepoMock.ensureTaskInGroup).toHaveBeenCalledWith(
+        { taskId: taskInputTwo.id, groupId, userId },
+        expectTransaction(),
+      );
+      const [[replacedGroupArg, trxArg]] = groupWriteRepoMock.replaceGroupWithTasks.mock.calls;
+      expect(replacedGroupArg).toBeInstanceOf(GroupWithTasks);
+      expect(replacedGroupArg.id).toBe(groupId);
+      expect(replacedGroupArg.userId).toBe(userId);
+      expect(replacedGroupArg.name).toBe('Updated');
+      expect(replacedGroupArg.description).toBe('New');
+      expect(replacedGroupArg.tasks).toHaveLength(2);
+      expect(trxArg).toEqual(expect.anything());
+      expect(groupReadRepoMock.getGroupWithTasksById).toHaveBeenCalledWith(
+        { groupId, userId },
+        { trx: expectTransaction(), throwError: true },
+      );
+      expect(res).toEqual({
+        data: {
+          id: groupId,
+          name: 'Updated',
+          description: 'New',
+          status: getGroupRaw().status,
+          userId,
+          progress: getGroupRaw().progress,
+          tasks: [
+            {
+              id: responseTask.id,
+              userId: responseTask.userId,
+              name: responseTask.name,
+              description: responseTask.description,
+              priority: responseTask.priority,
+              weight: responseTask.weight,
+              cancelReason: responseTask.cancelReason,
+              startDate: responseTask.startDate,
+              endDate: responseTask.endDate,
+              deadline: responseTask.deadline,
+              status: responseTask.status,
+              recurrence: responseTask.recurrence,
+            },
+          ],
+        },
+      });
     });
 
     test('should throw when group missing', async () => {
-    const payload: GoalReplaceGroup.Request = buildPayload({
-      data: {
-        id: 999,
-        userId: 9,
-        name: 'Updated',
-        description: 'New',
-        tasks: [],
-      },
-    });
-    groupWriteRepoMock.getGroupById.mockResolvedValueOnce(null);
+      const payload: GoalReplaceGroup.Request = buildPayload({
+        data: {
+          id: 999,
+          userId: 9,
+          name: 'Updated',
+          description: 'New',
+          tasks: [],
+        },
+      });
+      groupWriteRepoMock.getGroupById.mockResolvedValueOnce(null);
 
-    let error: unknown;
-    try {
-      await sendMessage<GoalReplaceGroup.Response, GoalReplaceGroup.Request>(
-        GoalReplaceGroup.pattern,
-        payload,
+      let error: unknown;
+      try {
+        await sendMessage<GoalReplaceGroup.Response, GoalReplaceGroup.Request>(
+          GoalReplaceGroup.pattern,
+          payload,
+        );
+      } catch (err) {
+        error = err;
+      }
+
+      expect(groupWriteRepoMock.getGroupById).toHaveBeenCalledWith(
+        { groupId: 999, userId: 9 },
+        expectTransaction(),
       );
-    } catch (err) {
-      error = err;
-    }
 
-    expect(groupWriteRepoMock.getGroupById).toHaveBeenCalledWith(
-      { groupId: 999, userId: 9 },
-      expectTransaction(),
-    );
-
-    expect(unwrapRpcError(error)).toMatchObject({
-      code: exceptionCode.groupNotExist.code,
-      key: 'GROUP_NOT_EXIST',
-      kind: RmqErrorKind.NOT_FOUND,
-      details: { groupId: 999 },
-    });
+      expect(unwrapRpcError(error)).toMatchObject({
+        code: exceptionCode.groupNotExist.code,
+        key: 'GROUP_NOT_EXIST',
+        kind: RmqErrorKind.NOT_FOUND,
+        details: { groupId: 999 },
+      });
     });
 
     test('should throw when task is missing', async () => {
-    const userId = 10;
-    const groupId = 300;
-    const payload: GoalReplaceGroup.Request = buildPayload({
-      data: {
-        id: groupId,
-        userId,
-        name: 'Updated',
-        description: 'New',
-        tasks: [
-          {
-            id: 555,
-            name: 'Task',
-            priority: 2,
-            weight: 10,
-          },
-        ],
-      },
-    });
-    groupWriteRepoMock.getGroupById.mockResolvedValueOnce(
-      getGroupWithTasks({ id: groupId, user_id: userId }),
-    );
-    tasksWriteRepoMock.getTaskById.mockResolvedValueOnce(null);
-
-    let error: unknown;
-    try {
-      await sendMessage<GoalReplaceGroup.Response, GoalReplaceGroup.Request>(
-        GoalReplaceGroup.pattern,
-        payload,
+      const userId = 10;
+      const groupId = 300;
+      const payload: GoalReplaceGroup.Request = buildPayload({
+        data: {
+          id: groupId,
+          userId,
+          name: 'Updated',
+          description: 'New',
+          tasks: [
+            {
+              id: 555,
+              name: 'Task',
+              priority: 2,
+              weight: 10,
+            },
+          ],
+        },
+      });
+      groupWriteRepoMock.getGroupById.mockResolvedValueOnce(
+        getGroupWithTasks({ id: groupId, user_id: userId }),
       );
-    } catch (err) {
-      error = err;
-    }
+      tasksWriteRepoMock.getTaskById.mockResolvedValueOnce(null);
 
-    expect(tasksWriteRepoMock.getTaskById).toHaveBeenCalledWith(
-      { taskId: 555, userId },
-      expectTransaction(),
-    );
-    expect(groupReadRepoMock.ensureTaskInGroup).not.toHaveBeenCalled();
-    expect(unwrapRpcError(error)).toMatchObject({
-      code: exceptionCode.taskNotExist.code,
-      key: 'TASK_NOT_EXIST',
-      kind: RmqErrorKind.NOT_FOUND,
-      details: { taskId: 555 },
-    });
+      let error: unknown;
+      try {
+        await sendMessage<GoalReplaceGroup.Response, GoalReplaceGroup.Request>(
+          GoalReplaceGroup.pattern,
+          payload,
+        );
+      } catch (err) {
+        error = err;
+      }
+
+      expect(tasksWriteRepoMock.getTaskById).toHaveBeenCalledWith(
+        { taskId: 555, userId },
+        expectTransaction(),
+      );
+      expect(groupReadRepoMock.ensureTaskInGroup).not.toHaveBeenCalled();
+      expect(unwrapRpcError(error)).toMatchObject({
+        code: exceptionCode.taskNotExist.code,
+        key: 'TASK_NOT_EXIST',
+        kind: RmqErrorKind.NOT_FOUND,
+        details: { taskId: 555 },
+      });
     });
 
     test('should throw when task not in group', async () => {
-    const userId = 10;
-    const groupId = 301;
-    const payload: GoalReplaceGroup.Request = buildPayload({
-      data: {
-        id: groupId,
-        userId,
-        name: 'Updated',
-        description: 'New',
-        tasks: [
-          {
-            id: 556,
-            name: 'Task',
-            priority: 2,
-            weight: 10,
-          },
-        ],
-      },
-    });
-    groupWriteRepoMock.getGroupById.mockResolvedValueOnce(
-      getGroupWithTasks({ id: groupId, user_id: userId }),
-    );
-    tasksWriteRepoMock.getTaskById.mockResolvedValueOnce(getTask({ id: 556, userId }));
-    groupReadRepoMock.ensureTaskInGroup.mockResolvedValueOnce(false);
-
-    let error: unknown;
-    try {
-      await sendMessage<GoalReplaceGroup.Response, GoalReplaceGroup.Request>(
-        GoalReplaceGroup.pattern,
-        payload,
+      const userId = 10;
+      const groupId = 301;
+      const payload: GoalReplaceGroup.Request = buildPayload({
+        data: {
+          id: groupId,
+          userId,
+          name: 'Updated',
+          description: 'New',
+          tasks: [
+            {
+              id: 556,
+              name: 'Task',
+              priority: 2,
+              weight: 10,
+            },
+          ],
+        },
+      });
+      groupWriteRepoMock.getGroupById.mockResolvedValueOnce(
+        getGroupWithTasks({ id: groupId, user_id: userId }),
       );
-    } catch (err) {
-      error = err;
-    }
+      tasksWriteRepoMock.getTaskById.mockResolvedValueOnce(getTask({ id: 556, userId }));
+      groupReadRepoMock.ensureTaskInGroup.mockResolvedValueOnce(false);
 
-    expect(groupReadRepoMock.ensureTaskInGroup).toHaveBeenCalledWith(
-      { taskId: 556, groupId, userId },
-      expectTransaction(),
-    );
-    expect(groupWriteRepoMock.replaceGroupWithTasks).not.toHaveBeenCalled();
-    expect(unwrapRpcError(error)).toMatchObject({
-      code: exceptionCode.taskNotInGroup.code,
-      key: 'TASK_NOT_IN_GROUP',
-      kind: RmqErrorKind.NOT_FOUND,
-      details: { taskId: 556, groupId },
-    });
+      let error: unknown;
+      try {
+        await sendMessage<GoalReplaceGroup.Response, GoalReplaceGroup.Request>(
+          GoalReplaceGroup.pattern,
+          payload,
+        );
+      } catch (err) {
+        error = err;
+      }
+
+      expect(groupReadRepoMock.ensureTaskInGroup).toHaveBeenCalledWith(
+        { taskId: 556, groupId, userId },
+        expectTransaction(),
+      );
+      expect(groupWriteRepoMock.replaceGroupWithTasks).not.toHaveBeenCalled();
+      expect(unwrapRpcError(error)).toMatchObject({
+        code: exceptionCode.taskNotInGroup.code,
+        key: 'TASK_NOT_IN_GROUP',
+        kind: RmqErrorKind.NOT_FOUND,
+        details: { taskId: 556, groupId },
+      });
     });
   });
 
   describe(`${GoalDeleteGroup.pattern}`, () => {
     test('should delete group', async () => {
-    const userId = 50;
-    const groupId = 80;
-    groupWriteRepoMock.getGroupById.mockResolvedValueOnce(
-      getGroupWithTasks({ id: groupId, user_id: userId, tasks: [] }),
-    );
-    groupWriteRepoMock.deleteById.mockResolvedValueOnce(true);
-    const payload: GoalDeleteGroup.Request = buildPayload({
-      data: { groupId, userId },
-    });
+      const userId = 50;
+      const groupId = 80;
+      groupWriteRepoMock.getGroupById.mockResolvedValueOnce(
+        getGroupWithTasks({ id: groupId, user_id: userId, tasks: [] }),
+      );
+      groupWriteRepoMock.deleteById.mockResolvedValueOnce(true);
+      const payload: GoalDeleteGroup.Request = buildPayload({
+        data: { groupId, userId },
+      });
 
-    const res = await sendMessage<GoalDeleteGroup.Response, GoalDeleteGroup.Request>(
-      GoalDeleteGroup.pattern,
-      payload,
-    );
+      const res = await sendMessage<GoalDeleteGroup.Response, GoalDeleteGroup.Request>(
+        GoalDeleteGroup.pattern,
+        payload,
+      );
 
-    expect(groupWriteRepoMock.getGroupById).toHaveBeenCalledWith(
-      { groupId, userId },
-      expectTransaction(),
-    );
-    expect(groupWriteRepoMock.deleteById).toHaveBeenCalledWith(
-      { groupId, userId },
-      expectTransaction(),
-    );
-    expect(res).toEqual({ data: true });
+      expect(groupWriteRepoMock.getGroupById).toHaveBeenCalledWith(
+        { groupId, userId },
+        expectTransaction(),
+      );
+      expect(groupWriteRepoMock.deleteById).toHaveBeenCalledWith(
+        { groupId, userId },
+        expectTransaction(),
+      );
+      expect(res).toEqual({ data: true });
     });
 
     test('should throw when group missing', async () => {
-    const payload: GoalDeleteGroup.Request = buildPayload({
-      data: { groupId: 81, userId: 51 },
-    });
-    groupWriteRepoMock.getGroupById.mockResolvedValueOnce(null);
+      const payload: GoalDeleteGroup.Request = buildPayload({
+        data: { groupId: 81, userId: 51 },
+      });
+      groupWriteRepoMock.getGroupById.mockResolvedValueOnce(null);
 
-    let error: unknown;
-    try {
-      await sendMessage<GoalDeleteGroup.Response, GoalDeleteGroup.Request>(
-        GoalDeleteGroup.pattern,
-        payload,
-      );
-    } catch (err) {
-      error = err;
-    }
+      let error: unknown;
+      try {
+        await sendMessage<GoalDeleteGroup.Response, GoalDeleteGroup.Request>(
+          GoalDeleteGroup.pattern,
+          payload,
+        );
+      } catch (err) {
+        error = err;
+      }
 
-    expect(groupWriteRepoMock.deleteById).not.toHaveBeenCalled();
-    expect(unwrapRpcError(error)).toMatchObject({
-      code: exceptionCode.groupNotExist.code,
-      key: 'GROUP_NOT_EXIST',
-      kind: RmqErrorKind.NOT_FOUND,
-      details: { groupId: 81 },
-    });
+      expect(groupWriteRepoMock.deleteById).not.toHaveBeenCalled();
+      expect(unwrapRpcError(error)).toMatchObject({
+        code: exceptionCode.groupNotExist.code,
+        key: 'GROUP_NOT_EXIST',
+        kind: RmqErrorKind.NOT_FOUND,
+        details: { groupId: 81 },
+      });
     });
 
     test('should throw when group has tasks', async () => {
-    const payload: GoalDeleteGroup.Request = buildPayload({
-      data: { groupId: 82, userId: 52 },
-    });
-    const taskView = getTaskView({ id: 21, userId: 52, name: 'Task in group' });
-    groupWriteRepoMock.getGroupById.mockResolvedValueOnce(
-      getGroupWithTasks({ id: 82, user_id: 52, tasks: [taskView] }),
-    );
-
-    let error: unknown;
-    try {
-      await sendMessage<GoalDeleteGroup.Response, GoalDeleteGroup.Request>(
-        GoalDeleteGroup.pattern,
-        payload,
+      const payload: GoalDeleteGroup.Request = buildPayload({
+        data: { groupId: 82, userId: 52 },
+      });
+      const taskView = getTaskView({ id: 21, userId: 52, name: 'Task in group' });
+      groupWriteRepoMock.getGroupById.mockResolvedValueOnce(
+        getGroupWithTasks({ id: 82, user_id: 52, tasks: [taskView] }),
       );
-    } catch (err) {
-      error = err;
-    }
 
-    expect(groupWriteRepoMock.deleteById).not.toHaveBeenCalled();
-    expect(unwrapRpcError(error)).toMatchObject({
-      code: exceptionCode.taskInvariantFailed.code,
-      key: 'INVARIANT_FAILED',
-      kind: RmqErrorKind.DOMAIN_INVARIANT_VIOLATION,
-      details: {
-        field: 'tasks',
-        message: "Group can't be delete if has at least one task",
-      },
-    });
+      let error: unknown;
+      try {
+        await sendMessage<GoalDeleteGroup.Response, GoalDeleteGroup.Request>(
+          GoalDeleteGroup.pattern,
+          payload,
+        );
+      } catch (err) {
+        error = err;
+      }
+
+      expect(groupWriteRepoMock.deleteById).not.toHaveBeenCalled();
+      expect(unwrapRpcError(error)).toMatchObject({
+        code: exceptionCode.taskInvariantFailed.code,
+        key: 'INVARIANT_FAILED',
+        kind: RmqErrorKind.DOMAIN_INVARIANT_VIOLATION,
+        details: {
+          field: 'tasks',
+          message: "Group can't be delete if has at least one task",
+        },
+      });
     });
 
     test('should throw on write conflict', async () => {
-    const payload: GoalDeleteGroup.Request = buildPayload({
-      data: { groupId: 83, userId: 53 },
-    });
-    groupWriteRepoMock.getGroupById.mockResolvedValueOnce(
-      getGroupWithTasks({ id: 83, user_id: 53, tasks: [] }),
-    );
-    groupWriteRepoMock.deleteById.mockResolvedValueOnce(false);
-
-    let error: unknown;
-    try {
-      await sendMessage<GoalDeleteGroup.Response, GoalDeleteGroup.Request>(
-        GoalDeleteGroup.pattern,
-        payload,
+      const payload: GoalDeleteGroup.Request = buildPayload({
+        data: { groupId: 83, userId: 53 },
+      });
+      groupWriteRepoMock.getGroupById.mockResolvedValueOnce(
+        getGroupWithTasks({ id: 83, user_id: 53, tasks: [] }),
       );
-    } catch (err) {
-      error = err;
-    }
+      groupWriteRepoMock.deleteById.mockResolvedValueOnce(false);
 
-    expect(groupWriteRepoMock.deleteById).toHaveBeenCalledWith(
-      { groupId: 83, userId: 53 },
-      expectTransaction(),
-    );
-    expect(unwrapRpcError(error)).toMatchObject({
-      code: exceptionCode.writeConflict.code,
-      key: 'GROUP_WRITE_CONFLICT',
-      kind: RmqErrorKind.INTERNAL,
-      details: { subjectId: 83, message: 'Group could not be deleted' },
-    });
+      let error: unknown;
+      try {
+        await sendMessage<GoalDeleteGroup.Response, GoalDeleteGroup.Request>(
+          GoalDeleteGroup.pattern,
+          payload,
+        );
+      } catch (err) {
+        error = err;
+      }
+
+      expect(groupWriteRepoMock.deleteById).toHaveBeenCalledWith(
+        { groupId: 83, userId: 53 },
+        expectTransaction(),
+      );
+      expect(unwrapRpcError(error)).toMatchObject({
+        code: exceptionCode.writeConflict.code,
+        key: 'GROUP_WRITE_CONFLICT',
+        kind: RmqErrorKind.INTERNAL,
+        details: { subjectId: 83, message: 'Group could not be deleted' },
+      });
     });
   });
 });

--- a/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/tasks-inbox.rmq.controller.test.ts
+++ b/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/tasks-inbox.rmq.controller.test.ts
@@ -41,10 +41,6 @@ describe('TasksInboxRmqController (rmq e2e)', () => {
   let client: ClientProxy;
   let sendMessage: ReturnType<typeof sendMessageBuilder>;
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   beforeAll(async () => {
     const moduleRef = await createTestingModule()
       .overrideProvider(TasksToken.WRITE_REPOSITORY)

--- a/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/tasks-inbox.rmq.controller.test.ts
+++ b/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/tasks-inbox.rmq.controller.test.ts
@@ -1,4 +1,3 @@
-import { GroupInboxReadRepository, TasksWriteRepository } from '@/modules/tasks/application/ports';
 import { Task } from '@/modules/tasks/domain';
 import { GroupsToken, TasksToken } from '@/modules/tasks/tokens';
 import { GoalAssignTaskToInbox, GoalCreateTaskInInbox, RmqErrorKind } from '@big-d/api-contracts';
@@ -15,7 +14,11 @@ import {
 } from '@shared/__tests__';
 import { getGroupInboxView, getTask, getTaskView } from '@shared/__tests__/entities';
 import { initTestEnvironment } from '@/../jest.setup';
-import { tasksReadRepoMock } from '@shared/__tests__/repository-mocks';
+import {
+  inboxReadRepoMock,
+  tasksReadRepoMock,
+  tasksWriteRepoMock,
+} from '@shared/__tests__/repository-mocks';
 
 initTestEnvironment();
 const toTaskResponse = (taskView: ReturnType<typeof getTaskView>) => ({
@@ -33,25 +36,14 @@ const toTaskResponse = (taskView: ReturnType<typeof getTaskView>) => ({
   recurrence: taskView.recurrence,
 });
 
-const tasksWriteRepoMock: Record<keyof TasksWriteRepository, jest.Mock> = {
-  getTaskById: jest.fn(),
-  createTask: jest.fn(),
-  deleteTask: jest.fn(),
-  changeTaskStatus: jest.fn(),
-  replaceTask: jest.fn(),
-  addTaskToGroup: jest.fn(),
-  removeTaskFromGroup: jest.fn(),
-};
-
-const inboxReadRepoMock: Record<keyof GroupInboxReadRepository, jest.Mock> = {
-  getInboxWithTasksByUserId: jest.fn(),
-  ensureTaskInInbox: jest.fn(),
-};
-
 describe('TasksInboxRmqController (rmq e2e)', () => {
   let ms: INestMicroservice;
   let client: ClientProxy;
   let sendMessage: ReturnType<typeof sendMessageBuilder>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   beforeAll(async () => {
     const moduleRef = await createTestingModule()

--- a/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/tasks.rmq.controller.test.ts
+++ b/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/tasks.rmq.controller.test.ts
@@ -53,10 +53,6 @@ describe('TasksRmqController (rmq e2e)', () => {
   let client: ClientProxy;
   let sendMessage: ReturnType<typeof sendMessageBuilder>;
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   beforeAll(async () => {
     const moduleRef = await createTestingModule()
       .overrideProvider(TasksToken.WRITE_REPOSITORY)

--- a/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/tasks.rmq.controller.test.ts
+++ b/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/tasks.rmq.controller.test.ts
@@ -1,9 +1,3 @@
-import {
-  GroupInboxReadRepository,
-  GroupsReadRepository,
-  GroupsWriteRepository,
-  TasksWriteRepository,
-} from '@/modules/tasks/application/ports';
 import { Task } from '@/modules/tasks/domain';
 import { GroupsToken, TasksToken } from '@/modules/tasks/tokens';
 import {
@@ -11,6 +5,7 @@ import {
   GoalCloneTask,
   GoalCreateTask,
   GoalDeleteTask,
+  GoalGetDiaryTasks,
   GoalReplaceTask,
   GoalUnassignTaskFromGroup,
   GoalUpdateInboxTask,
@@ -29,7 +24,13 @@ import {
 } from '@shared/__tests__';
 import { getGroupWithTasks, getTask, getTaskView } from '@shared/__tests__/entities';
 import { initTestEnvironment } from '@/../jest.setup';
-import { tasksReadRepoMock } from '@shared/__tests__/repository-mocks';
+import {
+  groupReadRepoMock,
+  groupWriteRepoMock,
+  inboxReadRepoMock,
+  tasksReadRepoMock,
+  tasksWriteRepoMock,
+} from '@shared/__tests__/repository-mocks';
 
 initTestEnvironment();
 const toTaskResponse = (taskView: ReturnType<typeof getTaskView>) => ({
@@ -47,40 +48,14 @@ const toTaskResponse = (taskView: ReturnType<typeof getTaskView>) => ({
   recurrence: taskView.recurrence,
 });
 
-const tasksWriteRepoMock: Record<keyof TasksWriteRepository, jest.Mock> = {
-  getTaskById: jest.fn(),
-  createTask: jest.fn(),
-  deleteTask: jest.fn(),
-  changeTaskStatus: jest.fn(),
-  replaceTask: jest.fn(),
-  addTaskToGroup: jest.fn(),
-  removeTaskFromGroup: jest.fn(),
-};
-
-const groupWriteRepoMock: Record<keyof GroupsWriteRepository, jest.Mock> = {
-  createGroup: jest.fn(),
-  deleteById: jest.fn(),
-  getGroupById: jest.fn(),
-  replaceGroupWithTasks: jest.fn(),
-};
-
-const groupReadRepoMock: Record<keyof GroupsReadRepository, jest.Mock> = {
-  getByName: jest.fn(),
-  getGroupById: jest.fn(),
-  getGroupWithTasksById: jest.fn(),
-  ensureTaskInGroup: jest.fn(),
-  getGroupListWithTasksByUserId: jest.fn(),
-};
-
-const inboxReadRepoMock: Record<keyof GroupInboxReadRepository, jest.Mock> = {
-  getInboxWithTasksByUserId: jest.fn(),
-  ensureTaskInInbox: jest.fn(),
-};
-
 describe('TasksRmqController (rmq e2e)', () => {
   let ms: INestMicroservice;
   let client: ClientProxy;
   let sendMessage: ReturnType<typeof sendMessageBuilder>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   beforeAll(async () => {
     const moduleRef = await createTestingModule()
@@ -1127,6 +1102,32 @@ describe('TasksRmqController (rmq e2e)', () => {
         kind: RmqErrorKind.NOT_FOUND,
         details: { taskId, groupId },
       });
+    });
+  });
+
+  describe(`${GoalGetDiaryTasks.pattern}`, () => {
+    test('should return diary tasks', async () => {
+      const userId = 81;
+      const taskView = getTaskView({ id: 9005, userId, name: 'Diary task' });
+      tasksReadRepoMock.getByRange.mockResolvedValueOnce([taskView]);
+
+      const payload: GoalGetDiaryTasks.Request = buildPayload({
+        data: {
+          userId,
+          from: '2024-01-01T00:00:00.000Z',
+          to: '2024-01-31T00:00:00.000Z',
+        },
+      });
+
+      const res = await sendMessage<GoalGetDiaryTasks.Response, GoalGetDiaryTasks.Request>(
+        GoalGetDiaryTasks.pattern,
+        payload,
+      );
+
+      expect(tasksReadRepoMock.getByRange).toHaveBeenCalledTimes(1);
+      const [, trxArg] = tasksReadRepoMock.getByRange.mock.calls[0];
+      expect(trxArg).toEqual(expectTransaction());
+      expect(res).toEqual({ data: [toTaskResponse(taskView)] });
     });
   });
 });

--- a/apps/goal-service/src/shared/__tests__/repository-mocks/index.ts
+++ b/apps/goal-service/src/shared/__tests__/repository-mocks/index.ts
@@ -1,4 +1,11 @@
-import { TasksReadRepository } from '@/modules/tasks/application/ports';
+import {
+  GroupInboxReadRepository,
+  GroupInboxWriteRepository,
+  GroupsReadRepository,
+  GroupsWriteRepository,
+  TasksReadRepository,
+  TasksWriteRepository,
+} from '@/modules/tasks/application/ports';
 
 const tasksReadRepoMock: Record<keyof TasksReadRepository, jest.Mock> = {
   getById: jest.fn(),
@@ -7,4 +14,45 @@ const tasksReadRepoMock: Record<keyof TasksReadRepository, jest.Mock> = {
   getByRange: jest.fn(),
 };
 
-export { tasksReadRepoMock };
+const tasksWriteRepoMock: Record<keyof TasksWriteRepository, jest.Mock> = {
+  getTaskById: jest.fn(),
+  createTask: jest.fn(),
+  deleteTask: jest.fn(),
+  changeTaskStatus: jest.fn(),
+  replaceTask: jest.fn(),
+  addTaskToGroup: jest.fn(),
+  removeTaskFromGroup: jest.fn(),
+};
+
+const groupWriteRepoMock: Record<keyof GroupsWriteRepository, jest.Mock> = {
+  createGroup: jest.fn(),
+  deleteById: jest.fn(),
+  getGroupById: jest.fn(),
+  replaceGroupWithTasks: jest.fn(),
+};
+
+const groupReadRepoMock: Record<keyof GroupsReadRepository, jest.Mock> = {
+  getByName: jest.fn(),
+  getGroupById: jest.fn(),
+  getGroupWithTasksById: jest.fn(),
+  ensureTaskInGroup: jest.fn(),
+  getGroupListWithTasksByUserId: jest.fn(),
+};
+
+const inboxReadRepoMock: Record<keyof GroupInboxReadRepository, jest.Mock> = {
+  getInboxWithTasksByUserId: jest.fn(),
+  ensureTaskInInbox: jest.fn(),
+};
+
+const inboxWriteRepoMock: Record<keyof GroupInboxWriteRepository, jest.Mock> = {
+  createInbox: jest.fn(),
+};
+
+export {
+  groupReadRepoMock,
+  groupWriteRepoMock,
+  inboxReadRepoMock,
+  inboxWriteRepoMock,
+  tasksReadRepoMock,
+  tasksWriteRepoMock,
+};


### PR DESCRIPTION
### Motivation
- Reduce duplication by centralizing RMQ repository mocks and reuse them across tasks/groups/inbox RMQ controller tests. 
- Increase coverage for RMQ controllers by adding missing endpoint cases and asserting transaction usage. 

### Description
- Added shared repository mocks in `apps/goal-service/src/shared/__tests__/repository-mocks/index.ts` and exported `tasksReadRepoMock`, `tasksWriteRepoMock`, `groupReadRepoMock`, `groupWriteRepoMock`, `inboxReadRepoMock`, and `inboxWriteRepoMock`. 
- Updated RMQ controller tests to consume shared mocks (`tasks.rmq.controller.test.ts`, `tasks-inbox.rmq.controller.test.ts`, `groups.rmq.controller.test.ts`, `groups-inbox.rmq.controller.test.ts`) and removed local duplicate mock definitions. 
- Grouped tests by endpoint (`describe` per endpoint) in `groups.rmq.controller.test.ts` and added `beforeEach` with `jest.clearAllMocks()` across controller test suites. 
- Added diary tasks coverage for `GoalGetDiaryTasks` in `tasks.rmq.controller.test.ts` and added explicit transaction assertions for read-by-range calls. 

### Testing
- No automated test runs were executed as part of this change (tests updated only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971b374ca548328b95866110e0b581c)