### PR TITLE
Add Vitest unit tests for api-utils value objects

### DIFF
--- a/libs/api-utils/src/value-objects/__tests__/base-value-object.test.ts
+++ b/libs/api-utils/src/value-objects/__tests__/base-value-object.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { BaseValueObject } from '../base-value-object';
+
+class TestValueObject extends BaseValueObject {
+  constructor(private readonly value: string) {
+    super();
+  }
+
+  public equals(other: TestValueObject): boolean {
+    return this.value === other.value;
+  }
+}
+
+describe('BaseValueObject', () => {
+  it('supports equality in subclasses', () => {
+    const first = new TestValueObject('same');
+    const second = new TestValueObject('same');
+    const third = new TestValueObject('different');
+
+    expect(first.equals(second)).toBe(true);
+    expect(first.equals(third)).toBe(false);
+  });
+});

--- a/libs/api-utils/src/value-objects/__tests__/date-vo.test.ts
+++ b/libs/api-utils/src/value-objects/__tests__/date-vo.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { DateVo } from '../date-vo';
+
+describe('DateVo', () => {
+  it('creates from ISO string and normalizes milliseconds', () => {
+    const dateVo = DateVo.create('2024-05-01T10:11:12.789Z');
+
+    expect(dateVo.value).toBe('2024-05-01T10:11:12.000Z');
+  });
+
+  it('creates from Date instance', () => {
+    const date = new Date('2024-05-01T10:11:12.345Z');
+    const dateVo = DateVo.create(date);
+
+    expect(dateVo.value).toBe('2024-05-01T10:11:12.000Z');
+  });
+
+  it('throws for non-ISO input', () => {
+    expect(() => DateVo.create('not-a-date')).toThrowError('must be ISO8601 format');
+  });
+
+  it('compares equality', () => {
+    const first = DateVo.create('2024-05-01T10:11:12.000Z');
+    const second = DateVo.create('2024-05-01T10:11:12.000Z');
+    const third = DateVo.create('2024-05-02T10:11:12.000Z');
+
+    expect(first.equals(second)).toBe(true);
+    expect(first.equals(third)).toBe(false);
+  });
+
+  it('checks relative ordering', () => {
+    const base = DateVo.create('2024-05-01T10:11:12.000Z');
+
+    expect(base.isBefore('2024-05-01T10:11:13.000Z')).toBe(true);
+    expect(base.isAfter('2024-05-01T10:11:11.000Z')).toBe(true);
+  });
+});

--- a/libs/api-utils/src/value-objects/__tests__/email.test.ts
+++ b/libs/api-utils/src/value-objects/__tests__/email.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { Email } from '../email';
+
+describe('Email', () => {
+  it('normalizes email addresses', () => {
+    const email = Email.create('  User@Example.COM ');
+
+    expect(email.value).toBe('user@example.com');
+  });
+
+  it('throws when empty', () => {
+    expect(() => Email.create('')).toThrowError('Email is required');
+  });
+
+  it('throws for invalid format', () => {
+    expect(() => Email.create('not-an-email')).toThrowError('Invalid email format');
+  });
+
+  it('provides the domain portion', () => {
+    const email = Email.create('user@example.com');
+
+    expect(email.getDomain()).toBe('example.com');
+  });
+
+  it('compares equality', () => {
+    const first = Email.create('user@example.com');
+    const second = Email.create('USER@example.com');
+    const third = Email.create('other@example.com');
+
+    expect(first.equals(second)).toBe(true);
+    expect(first.equals(third)).toBe(false);
+  });
+});

--- a/libs/api-utils/src/value-objects/__tests__/index.test.ts
+++ b/libs/api-utils/src/value-objects/__tests__/index.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { BaseValueObject, DateVo, Email, Name, Result } from '../index';
+
+describe('value-objects index', () => {
+  it('exports value object constructors', () => {
+    expect(BaseValueObject).toBeDefined();
+    expect(DateVo).toBeDefined();
+    expect(Email).toBeDefined();
+    expect(Name).toBeDefined();
+    expect(Result).toBeDefined();
+  });
+});

--- a/libs/api-utils/src/value-objects/__tests__/name.test.ts
+++ b/libs/api-utils/src/value-objects/__tests__/name.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { Name } from '../name';
+
+describe('Name', () => {
+  it('normalizes input with trimming', () => {
+    const name = Name.create('  Jane Doe  ');
+
+    expect(name.value).toBe('Jane Doe');
+  });
+
+  it('throws for empty string', () => {
+    expect(() => Name.create('   ')).toThrowError('must not be empty string');
+  });
+
+  it('throws when longer than limit', () => {
+    const longName = 'a'.repeat(Name.CHAR_LIMIT + 1);
+
+    expect(() => Name.create(longName)).toThrowError('Limit is');
+  });
+
+  it('compares equality', () => {
+    const first = Name.create('Jane Doe');
+    const second = Name.create('Jane Doe');
+    const third = Name.create('John Doe');
+
+    expect(first.equals(second)).toBe(true);
+    expect(first.equals(third)).toBe(false);
+  });
+});

--- a/libs/api-utils/src/value-objects/__tests__/result.test.ts
+++ b/libs/api-utils/src/value-objects/__tests__/result.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { Result } from '../result';
+
+describe('Result', () => {
+  it('creates when within range', () => {
+    const result = Result.create(50);
+
+    expect(result.value).toBe(50);
+  });
+
+  it('throws when outside range', () => {
+    expect(() => Result.create(-1)).toThrowError('Result available value range');
+    expect(() => Result.create(101)).toThrowError('Result available value range');
+  });
+
+  it('compares equality', () => {
+    const first = Result.create(80);
+    const second = Result.create(80);
+    const third = Result.create(60);
+
+    expect(first.equals(second)).toBe(true);
+    expect(first.equals(third)).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for the value object implementations in `libs/api-utils/src/value-objects` to catch regressions in normalization, validation, and equality logic.
- Provide a central `__tests__` suite to validate exported constructors from the value-object `index` so library consumers are covered.

### Description
- Added a new `__tests__` directory under `libs/api-utils/src/value-objects` containing tests for `BaseValueObject`, `DateVo`, `Email`, `Name`, `Result`, and the `index` exports.
- Tests validate Date normalization and ordering (`DateVo`), email normalization and domain extraction (`Email`), name trimming and length validation (`Name`), numeric range checks (`Result`), and equality behavior for the base class (`BaseValueObject`).
- Tests are implemented with `vitest` to match the package test runner and live alongside source files for easy maintenance.

### Testing
- Ran `pnpm --filter @big-d/api-utils test` which executed the `vitest` suite for the package and completed successfully.
- Test run result: 6 test files executed and all tests passed (19 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819a84d6848328aa8a5535b552837d)