### PR TITLE
test(rmq): add tests for assignable tasks and pass trx to group check

### DIFF
--- a/apps/goal-service/src/modules/tasks/application/queries/get-assignable-tasks-to-group/get-assignable-tasks-to-group.handler.ts
+++ b/apps/goal-service/src/modules/tasks/application/queries/get-assignable-tasks-to-group/get-assignable-tasks-to-group.handler.ts
@@ -29,7 +29,7 @@ export class GetAssignableTasksToGroupHandler implements IQueryHandler<GetAssign
     return this.db.runTransaction(async (trx) => {
       const { userId, groupId, search } = input;
 
-      await this.groupCheckerService.ensureGroupExists({ userId, groupId });
+      await this.groupCheckerService.ensureGroupExists({ userId, groupId }, { trx });
 
       const specifications = and(
         TaskByUserId(userId),

--- a/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/tasks.rmq.controller.test.ts
+++ b/apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/tasks.rmq.controller.test.ts
@@ -6,6 +6,7 @@ import {
   GoalCreateTask,
   GoalDeleteTask,
   GoalGetDiaryTasks,
+  GoalGetAssignableTasksToGroup,
   GoalReplaceTask,
   GoalUnassignTaskFromGroup,
   GoalUpdateInboxTask,
@@ -1124,6 +1125,75 @@ describe('TasksRmqController (rmq e2e)', () => {
       const [, trxArg] = tasksReadRepoMock.getByRange.mock.calls[0];
       expect(trxArg).toEqual(expectTransaction());
       expect(res).toEqual({ data: [toTaskResponse(taskView)] });
+    });
+  });
+
+  describe(`${GoalGetAssignableTasksToGroup.pattern}`, () => {
+    test('should return assignable tasks', async () => {
+      const userId = 90;
+      const groupId = 120;
+      const taskView = getTaskView({ id: 9010, userId, name: 'Assignable' });
+
+      groupWriteRepoMock.getGroupById.mockResolvedValueOnce(
+        getGroupWithTasks({ id: groupId, user_id: userId }),
+      );
+      tasksReadRepoMock.getMany.mockResolvedValueOnce([taskView]);
+
+      const payload: GoalGetAssignableTasksToGroup.Request = buildPayload({
+        data: {
+          userId,
+          groupId,
+          search: 'Assign',
+        },
+      });
+
+      const res = await sendMessage<
+        GoalGetAssignableTasksToGroup.Response,
+        GoalGetAssignableTasksToGroup.Request
+      >(GoalGetAssignableTasksToGroup.pattern, payload);
+
+      expect(groupWriteRepoMock.getGroupById).toHaveBeenCalledTimes(1);
+      const [, groupTrx] = groupWriteRepoMock.getGroupById.mock.calls[0];
+      expect(groupTrx).toEqual(expectTransaction());
+      expect(tasksReadRepoMock.getMany).toHaveBeenCalledTimes(1);
+      const [, , tasksTrx] = tasksReadRepoMock.getMany.mock.calls[0];
+      expect(tasksTrx).toEqual(expectTransaction());
+      expect(res).toEqual({ data: [toTaskResponse(taskView)] });
+    });
+
+    test('should throw when group missing', async () => {
+      const userId = 91;
+      const groupId = 121;
+
+      groupWriteRepoMock.getGroupById.mockResolvedValueOnce(null);
+
+      const payload: GoalGetAssignableTasksToGroup.Request = buildPayload({
+        data: {
+          userId,
+          groupId,
+        },
+      });
+
+      let error: unknown;
+      try {
+        await sendMessage<
+          GoalGetAssignableTasksToGroup.Response,
+          GoalGetAssignableTasksToGroup.Request
+        >(GoalGetAssignableTasksToGroup.pattern, payload);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(groupWriteRepoMock.getGroupById).toHaveBeenCalledTimes(1);
+      const [, groupTrx] = groupWriteRepoMock.getGroupById.mock.calls[0];
+      expect(groupTrx).toEqual(expectTransaction());
+      expect(tasksReadRepoMock.getMany).not.toHaveBeenCalled();
+      expect(unwrapRpcError(error)).toMatchObject({
+        code: exceptionCode.groupNotExist.code,
+        key: 'GROUP_NOT_EXIST',
+        kind: RmqErrorKind.NOT_FOUND,
+        details: { groupId },
+      });
     });
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure the assignable-tasks query validates group existence inside the same DB transaction so repository calls use the test transaction context.
- Add RMQ controller coverage for the assignable-tasks endpoint to cover success and error paths, including transaction propagation and exception format checks.

### Description
- Updated `GetAssignableTasksToGroupHandler` to call `groupCheckerService.ensureGroupExists` with `{ trx }` so the group existence check runs in the transaction. (`apps/goal-service/src/modules/tasks/application/queries/get-assignable-tasks-to-group/get-assignable-tasks-to-group.handler.ts`)
- Added RMQ e2e-style tests for `GoalGetAssignableTasksToGroup` in `tasks.rmq.controller.test.ts` that cover a successful response and the missing-group error path, assert repository calls were made, assert transaction objects were passed to repository mocks, and validate response/exception shapes. (`apps/goal-service/src/modules/tasks/presentation/rmq/__tests__/tasks.rmq.controller.test.ts`)
- Tests reuse existing shared test helpers, entities in `@shared/__tests__/entities`, and repository mocks in `apps/goal-service/src/shared/__tests__/repository-mocks`.

### Testing
- No automated tests were executed as part of this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982108986c08328ae0d9d823547ac80)